### PR TITLE
content: reconcile blog numbers (2-3x throughput, 10+ years)

### DIFF
--- a/content/blog/2-3x-not-100x.mdx
+++ b/content/blog/2-3x-not-100x.mdx
@@ -37,7 +37,7 @@ I don't want you to take "2-3x" on faith either. Here's the actual run.
 - **9 batches** of parallel agents. Each agent got one issue, one worktree, and the CLAUDE.md dispatch contract. I ran them concurrently, not one after another — that parallelism is where the speed actually comes from.
 - **2.5 working days**, start to merged.
 
-Now the baseline, which is the part most "multiplier" claims quietly omit. The comparison isn't *me versus me typing slower*. It's the same 30 PRs delivered by me alone, the way I did it for nine years: pick up the issue, write it, test it, review my own work, ship. For a batch of this size and complexity, that's roughly **a week** of solo-senior effort — closer to a week and a half for the items with real complexity.
+Now the baseline, which is the part most "multiplier" claims quietly omit. The comparison isn't *me versus me typing slower*. It's the same 30 PRs delivered by me alone, the way I did it for 10+ years: pick up the issue, write it, test it, review my own work, ship. For a batch of this size and complexity, that's roughly **a week** of solo-senior effort — closer to a week and a half for the items with real complexity.
 
 About a week of work in two and a half days. That's the 2-3x. Measured across the whole pipeline, including the step everyone else drops.
 

--- a/content/blog/30-prs-in-2-5-days.mdx
+++ b/content/blog/30-prs-in-2-5-days.mdx
@@ -71,7 +71,7 @@ Here's the thing the "30 PRs in 2.5 days" number hides until you've lived it.
 
 I did not spend 2.5 days waiting on agents to write code. Generation is the cheap phase now — a batch of agents produces a stack of PRs faster than I can read one carefully. The 2.5 days was almost entirely *review*: reading every diff adversarially, assuming it's wrong until proven safe, checking the security gates, the error paths, the scope against the issue, and whether the tests actually exercise the risk instead of dancing around it.
 
-That inversion is the real story of AI-native delivery. For most of my nine years, generation was the constraint — you were limited by how fast a human could write correct code. Now generation is nearly free and **review is the scarce resource.** The multiplier you can safely run is set entirely by how much code one senior engineer can adversarially review, not by how much the agents can produce.
+That inversion is the real story of AI-native delivery. For most of my 10+ years, generation was the constraint — you were limited by how fast a human could write correct code. Now generation is nearly free and **review is the scarce resource.** The multiplier you can safely run is set entirely by how much code one senior engineer can adversarially review, not by how much the agents can produce.
 
 Which is also why I say **2–3x, not 100x.** Anyone quoting you a 100x multiplier has quietly dropped the review step — because if they were reviewing the output the way I review it, they'd hit the same ceiling I do. The agents can generate 100x. You cannot safely *merge* 100x. The honest number is bounded by the bottleneck, and the bottleneck is a human reading carefully.
 

--- a/content/blog/claude-code-changed-how-i-ship-software.mdx
+++ b/content/blog/claude-code-changed-how-i-ship-software.mdx
@@ -2,7 +2,7 @@
 title: "Claude Code Changed How I Ship Software"
 date: "2026-03-30"
 tags: ["ai", "claude-code", "developer-productivity", "software-engineering"]
-description: "How I went from writing every line to orchestrating AI agents — and why 10 years of engineering experience matters more now, not less."
+description: "How I went from writing every line to orchestrating AI agents — and why 10+ years of engineering experience matters more now, not less."
 published: true
 ---
 
@@ -56,7 +56,7 @@ I'm going to be specific because most AI productivity content is either breathle
 
 **Review overhead: 5-15 minutes per PR.** That's 2.5-7.5 hours of review for 30 PRs. Not free.
 
-**Real throughput: 4-5x.** Not 100x. Not 10x. Four to five times more productive than working solo. That's still transformative, but let's not pretend it's magic.
+**Real throughput: 2-3x.** Not 100x. Not 10x. Two to three times more productive than working solo. That's still transformative, but let's not pretend it's magic.
 
 **Cost: $50-80 for a heavy batch week.** Less than a junior dev's hourly rate for one afternoon.
 


### PR DESCRIPTION
Follow-up to #5. The blog was showing two different numbers publicly after #5 merged.

**Fixes the live inconsistency:**
- Flagship `claude-code-changed-how-i-ship-software` throughput **4-5x → 2-3x** (matches the honest number in the new posts).
- Experience unified to **10+ years** (flagship was 10+, the 4 new posts said 9). Canonical = 10+ per author.

Content-only, two-line-scope edits. No structural changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)