### PR TITLE
fix: remove next/error from App Router global-error (fixes dev-boot crash)

### DIFF
--- a/app/global-error.jsx
+++ b/app/global-error.jsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Error from "next/error";
 import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 
@@ -11,10 +10,16 @@ export default function GlobalError({ error }) {
     console.error("Global error caught:", error);
   }, [error]);
 
+  // App Router global-error must render its own <html>/<body>. next/error is a
+  // Pages Router component and pulls next/head + pages/_error into this lazy
+  // client chunk, which breaks RSC module resolution in dev — so render markup.
   return (
-    <html>
+    <html lang="en">
       <body>
-        <Error />
+        <h2>Something went wrong.</h2>
+        <button type="button" onClick={() => window.location.reload()}>
+          Try again
+        </button>
       </body>
     </html>
   );


### PR DESCRIPTION
## The bug
`next dev` rendered `TypeError: Cannot read properties of undefined (reading 'call')` on **every** route (homepage included). Production was unaffected.

## Root cause
`app/global-error.jsx` imported `next/error` — a **Pages Router** component. It transitively pulls `next/head` + `next/dist/pages/_error` into the App Router's global-error client chunk (which wraps every route). In `next dev`'s on-demand compilation those Pages-Router modules never get a valid webpack factory, so RSC's lazy `requireModule` calls `.call` on `undefined` during Head/metadata render. Production bundles the whole graph up front → factory exists → fine.

Evidence: `global-error` chunk went **116KB → 45KB** with all Pages-Router modules gone after the change.

## Fix
Render the boundary's own `<html>/<body>` markup instead of `<Error />`; keep the Sentry capture.

## Verified
Local `next dev` (hard reload) now boots clean on `/` and `/blog/[slug]` — no overlay.

Credit: root-caused via scientific-debugger after 7 config/dependency hypotheses were falsified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)