### PR TITLE
feat: rewrite homepage to Ship/Verify positioning

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,40 +1,24 @@
 import Hero from "@/components/Hero";
+import ProofBand from "@/components/ProofBand";
+import ShipVerify from "@/components/ShipVerify";
+import Offers from "@/components/Offers";
+import CaseStudy from "@/components/CaseStudy";
+import WhoFor from "@/components/WhoFor";
+import FinalCta from "@/components/FinalCta";
 import { FloatingNav } from "@/components/ui/FloatingNav";
 import { navItems } from "@/data";
 import dynamic from "next/dynamic";
-import { Suspense } from "react";
-import { 
-  ProjectSkeleton, 
-  TestimonialSkeleton, 
-  ExperienceSkeleton 
+import {
+  TestimonialSkeleton,
+  ExperienceSkeleton,
 } from "@/components/ui/Skeleton";
-
-// Dynamic imports with loading components for better performance
-const About = dynamic(() => import("@/components/About"), {
-  loading: () => <div className="h-screen animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" />
-});
-
-const Projects = dynamic(() => import("@/components/Projects"), {
-  loading: () => (
-    <section className="py-20" aria-label="Projects loading">
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-2">
-        <ProjectSkeleton />
-        <ProjectSkeleton />
-      </div>
-    </section>
-  )
-});
 
 const Experience = dynamic(() => import("@/components/Experience"), {
   loading: () => (
     <section className="py-20" aria-label="Experience loading">
       <ExperienceSkeleton />
     </section>
-  )
-});
-
-const Approach = dynamic(() => import("@/components/Approach"), {
-  loading: () => <section className="h-96 animate-pulse bg-slate-100 dark:bg-slate-800 rounded-lg" aria-label="Approach loading" />
+  ),
 });
 
 const Testimonials = dynamic(() => import("@/components/Testimonials"), {
@@ -42,38 +26,38 @@ const Testimonials = dynamic(() => import("@/components/Testimonials"), {
     <section className="py-20" aria-label="Testimonials loading">
       <TestimonialSkeleton />
     </section>
-  )
+  ),
 });
 
 const Footer = dynamic(() => import("@/components/Footer"), {
-  loading: () => <footer className="h-32 animate-pulse bg-slate-100 dark:bg-slate-800" aria-label="Footer loading" />
+  loading: () => (
+    <footer
+      className="h-32 animate-pulse bg-slate-100 dark:bg-slate-800"
+      aria-label="Footer loading"
+    />
+  ),
 });
 
 export default function Home() {
   return (
-    <main className="relative dark:bg-black-100 bg-white flex justify-center items-center flex-col overflow-hidden mx-auto px-5 sm:px-10">
-      <div className="max-w-7xl w-full">
-        <FloatingNav
-          navItems={navItems}
-        />
-        <Hero />
-        <section id="about" aria-labelledby="about-heading">
-          <About />
-        </section>
-        <section id="experience" aria-labelledby="experience-heading">
+    <main className="relative dark:bg-black-100 bg-white overflow-hidden">
+      <FloatingNav navItems={navItems} />
+      <Hero />
+      <ProofBand />
+      <ShipVerify />
+      <Offers />
+      <CaseStudy />
+      <WhoFor />
+      <div className="max-w-7xl mx-auto px-5 sm:px-10">
+        <section aria-label="Track record">
           <Experience />
-          <div id="projects" aria-labelledby="projects-heading">
-            <Projects />
-          </div>
-        </section>
-        <section id="approach" aria-labelledby="approach-heading">
-          <Approach />
         </section>
         <section id="testimonials" aria-labelledby="testimonials-heading">
           <Testimonials />
         </section>
-        <Footer />
       </div>
+      <FinalCta />
+      <Footer />
     </main>
   );
 }

--- a/components/CaseStudy.tsx
+++ b/components/CaseStudy.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+
+const CaseStudy = () => {
+  return (
+    <section id="work" className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto rounded-2xl border border-white/10 bg-black-200/40 p-8 md:p-12">
+        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-blue-100">
+          Case study
+        </span>
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight mt-3 text-balance">
+          30 reviewed PRs in 2.5 days — and the 3 vulnerabilities that almost
+          shipped.
+        </h2>
+        <p className="text-white-200 mt-5 leading-relaxed max-w-3xl">
+          Nine agent batches ran a backlog through the harness in parallel. The
+          agents produced 30 PRs. The tests passed. The adversarial review
+          caught 3 shell-injection vulnerabilities before any of them merged.
+          This is what the honest 2-3x actually looks like — including what the
+          agents got wrong.
+        </p>
+        <div className="flex flex-wrap items-center gap-4 mt-8">
+          <Link
+            href="/blog/30-prs-in-2-5-days"
+            className="text-sm font-semibold text-purple hover:underline underline-offset-4"
+          >
+            Read the anatomy of nine agent batches →
+          </Link>
+          <span className="text-white-200/40">·</span>
+          <a
+            href="#contact"
+            className="text-sm font-medium text-blue-100 hover:text-purple transition-colors"
+          >
+            Run this on your backlog
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CaseStudy;

--- a/components/FinalCta.tsx
+++ b/components/FinalCta.tsx
@@ -1,0 +1,37 @@
+import MagicButton from "./ui/MagicButton";
+import { FaLocationArrow } from "react-icons/fa6";
+
+const FinalCta = () => {
+  return (
+    <section className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto rounded-2xl border border-white/10 bg-black-200/60 p-10 md:p-16 text-center">
+        <p className="font-mono text-sm text-purple">
+          2-3x, not 100x — and here&apos;s what the agents get wrong.
+        </p>
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight mt-4 text-balance max-w-3xl mx-auto">
+          Bring me a backlog. I&apos;ll ship it at agent speed and review every
+          PR for security before it reaches you.
+        </h2>
+        <p className="text-white-200 mt-4">
+          You triage and merge. I&apos;m accountable for what lands.
+        </p>
+        <div className="flex justify-center mt-8">
+          <a href="#contact" aria-label="Book a scoping call">
+            <MagicButton
+              title="Book a scoping call"
+              icon={<FaLocationArrow />}
+              position="right"
+            />
+          </a>
+        </div>
+        <p className="text-xs text-white-200/60 mt-6 max-w-xl mx-auto">
+          The verify layer is one senior human and doesn&apos;t parallelize — so
+          only a few sprints run at once. When the slots are full, new
+          engagements join a dated waitlist.
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default FinalCta;

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { GridBackground } from "./ui/GridBackground";
 import MagicButton from "./ui/MagicButton";
 import { TextGenerateEffect } from "./ui/TextGenerateEffect";
@@ -7,46 +6,54 @@ import SpotlightBackground from "./ui/SpotlightBackground";
 
 const Hero = () => {
   return (
-    <section className="h-[100vh]" id="home" aria-labelledby="hero-heading">
+    <section className="min-h-[100vh]" id="home" aria-labelledby="hero-heading">
       <SpotlightBackground />
       <div>
         <GridBackground />
       </div>
 
-      <div className="h-full flex justify-center items-center relative z-10">
-        <div className="max-w-[89vw] md:max-w-2xl lg:max-w-[60vw] flex justify-center items-center flex-col">
+      <div className="min-h-[100vh] flex justify-center items-center relative z-10 py-28">
+        <div className="max-w-[89vw] md:max-w-2xl lg:max-w-[62vw] flex justify-center items-center flex-col">
           <p className="uppercase tracking-widest text-xs text-center text-blue-100 max-w-80">
-            Dynamic Web Magic with Next.js
+            AI-Native Delivery · Ship / Verify
           </p>
 
           <h1 id="hero-heading" className="sr-only">
-            Adrian Rusan - Full-Stack Engineer Portfolio
+            Agent-speed delivery you can actually merge — AI-native delivery
+            with adversarial security review by Adrian Rusan
           </h1>
 
           <TextGenerateEffect
             className="text-center text-[40px] md:text-5xl lg:text-6xl"
-            words="Transforming Concepts into Seamless User Experiences"
+            words="Agent-speed delivery you can actually merge."
           />
 
-          <p className="text-center tracking-wider mb-4 text-sm md:text-lg lg:text-2xl">
-            Hi, I&apos;m <strong>Adrian Rusan</strong>, a{" "}
-            <strong>Full-Stack Engineer</strong> based in{" "}
-            <strong>Romania</strong> with{" "}
-            <strong>10+ years of experience</strong> in modern web development.
+          <p className="text-center tracking-wide mb-2 mt-2 text-sm md:text-lg lg:text-xl text-white-200 max-w-3xl">
+            I run fleets of Claude Code agents to ship production software 2-3x
+            faster — then I adversarially review every pull request myself,
+            because I&apos;ve caught the shell-injection bugs the agents wrote
+            that the tests passed clean.
           </p>
 
-          <Link
-            href="https://utfs.io/a/23x7w9tiht/7iidzn1TwzukCxvpcPXoxIjwOYaTyPZtGk0mVdeKgr9LH8hD"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Download Adrian Rusan's Resume (opens in new tab)"
-          >
-            <MagicButton
-              title="See my Resume"
-              icon={<FaLocationArrow />}
-              position="right"
-            />
-          </Link>
+          <p className="text-center font-mono text-xs md:text-sm text-purple mt-4 border-l-2 border-purple pl-3">
+            2-3x, not 100x — and here&apos;s what the agents get wrong.
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 mt-2">
+            <a href="#contact" aria-label="Book a scoping call">
+              <MagicButton
+                title="Book a scoping call"
+                icon={<FaLocationArrow />}
+                position="right"
+              />
+            </a>
+            <a
+              href="#offers"
+              className="text-sm font-medium text-blue-100 hover:text-purple transition-colors md:mt-10"
+            >
+              See how the sprint works →
+            </a>
+          </div>
         </div>
       </div>
     </section>

--- a/components/Offers.tsx
+++ b/components/Offers.tsx
@@ -1,0 +1,51 @@
+import { offers } from "@/data";
+
+const Offers = () => {
+  return (
+    <section id="offers" className="px-5 sm:px-10 py-20">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-center">
+          Three ways to work together.
+        </h2>
+        <p className="text-white-200 text-center mt-3 max-w-2xl mx-auto">
+          One two-step — agents ship, a senior human verifies — sold three ways.
+          Every engagement is fixed-scope and priced before we start.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mt-12">
+          {offers.map((offer) => (
+            <div
+              key={offer.id}
+              className={`relative flex flex-col rounded-xl p-6 bg-black-200/40 border ${offer.featured ? "border-purple shadow-[inset_0_0_0_1px_#CBACF9]" : "border-white/10"}`}
+            >
+              {offer.badge && (
+                <span className="font-mono text-[10px] font-bold uppercase tracking-[0.1em] text-purple mb-3">
+                  {offer.badge}
+                </span>
+              )}
+              <h3 className="text-lg font-semibold mb-3 tracking-tight">
+                {offer.title}
+              </h3>
+              <p className="text-sm text-white-200 leading-relaxed flex-1">
+                {offer.body}
+              </p>
+              <a
+                href="#contact"
+                className="text-sm font-medium text-purple hover:underline underline-offset-4 mt-5"
+              >
+                Learn more →
+              </a>
+            </div>
+          ))}
+        </div>
+
+        <p className="text-center text-sm text-white-200/80 mt-8 max-w-2xl mx-auto">
+          The verify layer is one senior human and doesn&apos;t parallelize — so
+          only a few engagements run at once.
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default Offers;

--- a/components/ProofBand.tsx
+++ b/components/ProofBand.tsx
@@ -1,0 +1,28 @@
+import { proofStats } from "@/data";
+
+const ProofBand = () => {
+  return (
+    <section aria-label="Proof by the numbers" className="px-5 sm:px-10">
+      <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 border border-white/10 rounded-xl overflow-hidden bg-black-200/40">
+        {proofStats.map((stat, i) => (
+          <div
+            key={stat.figure}
+            className={`p-6 md:p-8 ${i !== 0 ? "border-t md:border-t-0 md:border-l border-white/10" : ""}`}
+          >
+            <div className="text-3xl md:text-4xl font-bold tracking-tight tabular-nums">
+              {stat.figure}
+            </div>
+            <p className="font-mono text-[11px] md:text-xs leading-relaxed text-white-200 mt-3">
+              {stat.label}
+            </p>
+          </div>
+        ))}
+      </div>
+      <p className="max-w-7xl mx-auto text-center text-xs text-white-200/70 mt-4">
+        Real numbers from real work. No projections, no &quot;up to.&quot;
+      </p>
+    </section>
+  );
+};
+
+export default ProofBand;

--- a/components/ShipVerify.tsx
+++ b/components/ShipVerify.tsx
@@ -1,0 +1,60 @@
+import { shipVerify } from "@/data";
+
+const ShipVerify = () => {
+  return (
+    <section id="ship-verify" className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto">
+        {/* The problem */}
+        <div className="max-w-3xl">
+          <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-balance">
+            You have the backlog. You don&apos;t have the headcount. And
+            you&apos;ve seen what unsupervised agents ship.
+          </h2>
+          <p className="text-white-200 mt-5 leading-relaxed">
+            You&apos;re months behind on a roadmap you can&apos;t hire your way
+            out of fast enough. The AI-agent pitch is tempting — everyone&apos;s
+            promising 10x, 100x, a team-in-a-box. But you&apos;ve read the code
+            agents write. You know it goes green on tests and still carries a
+            confident vulnerability into your payment flow. And you&apos;re the
+            name on the incident report if it does.
+          </p>
+          <p className="text-white mt-4 font-medium">
+            Speed without review isn&apos;t velocity. It&apos;s a liability with
+            a shorter fuse.
+          </p>
+        </div>
+
+        {/* The two-step */}
+        <h3 className="text-xl md:text-2xl font-bold mt-16 mb-6 text-balance">
+          The whole thing is two steps. Most vendors only sell you the first.
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-white/10 border border-white/10 rounded-xl overflow-hidden">
+          {shipVerify.map((step) => (
+            <div
+              key={step.tag}
+              className={`p-6 md:p-8 ${step.tag === "VERIFY" ? "bg-black-200/60 border-l-2 border-purple" : "bg-black-200/30"}`}
+            >
+              <span
+                className={`font-mono text-xs font-bold tracking-[0.14em] ${step.tag === "VERIFY" ? "text-purple" : "text-blue-100"}`}
+              >
+                {step.tag}
+              </span>
+              <h4 className="text-lg font-semibold mt-2 mb-2">
+                {step.heading}
+              </h4>
+              <p className="text-sm text-white-200 leading-relaxed">
+                {step.body}
+              </p>
+            </div>
+          ))}
+        </div>
+        <p className="text-sm text-white-200/80 mt-4">
+          Speed you can buy anywhere now. The verify layer is the part
+          that&apos;s rare — and the part that&apos;s accountable.
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default ShipVerify;

--- a/components/WhoFor.tsx
+++ b/components/WhoFor.tsx
@@ -1,0 +1,49 @@
+import { whoFor } from "@/data";
+
+const WhoFor = () => {
+  return (
+    <section aria-label="Who this is for" className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-balance">
+          Built for a specific buyer. Wrong for a few others.
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-10">
+          <div className="rounded-xl border border-green-500/30 bg-green-500/5 p-6">
+            <h3 className="font-mono text-xs uppercase tracking-[0.1em] text-green-400 mb-4">
+              This is for you if
+            </h3>
+            <ul className="flex flex-col gap-3">
+              {whoFor.forList.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-3 text-sm text-white-200 leading-relaxed"
+                >
+                  <span className="text-green-400 flex-none">+</span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-black-200/30 p-6">
+            <h3 className="font-mono text-xs uppercase tracking-[0.1em] text-white-200/60 mb-4">
+              This isn&apos;t for you if
+            </h3>
+            <ul className="flex flex-col gap-3">
+              {whoFor.notForList.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-3 text-sm text-white-200/70 leading-relaxed"
+                >
+                  <span className="text-white-200/40 flex-none">−</span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WhoFor;

--- a/data/index.ts
+++ b/data/index.ts
@@ -1,19 +1,88 @@
 export const navItems = [
-  { name: "About", link: "#about" },
-  { name: "Projects", link: "#projects" },
-  { name: "Testimonials", link: "#testimonials" },
+  { name: "How it works", link: "#ship-verify" },
+  { name: "Services", link: "#offers" },
+  { name: "Work", link: "#work" },
   { name: "Blog", link: "/blog" },
   { name: "Contact", link: "#contact" },
 ];
 
-export const techStackLeft = [
-  'Next.js',
-  'React.js',
-  'Tailwind CSS',
-  'TypeScript',
+// --- Ship / Verify homepage content ---
+
+export const proofStats = [
+  {
+    figure: "30",
+    label: "reviewed PRs · 9 agent batches · 2.5 days",
+  },
+  {
+    figure: "3",
+    label: "shell-injection vulnerabilities caught — that passed the tests",
+  },
+  {
+    figure: "10+ yrs",
+    label: "in production: Ipsos → PGL Esports → GoSocial → Bono Fintech",
+  },
 ];
 
-export const techStackRight = ['SQL', 'REST API', 'Node.js', 'MongoDB'];
+export const shipVerify = [
+  {
+    tag: "SHIP",
+    heading: "The agents write the volume",
+    body: "Fleets of Claude Code agents run in parallel git worktrees, each dispatched a ticket and driven by your CLAUDE.md conventions. This is where the 2-3x comes from: a small team's throughput from one operator and a harness.",
+  },
+  {
+    tag: "VERIFY",
+    heading: "A senior human reviews every PR",
+    body: "Every agent PR goes through a line-by-line adversarial review before it reaches you. Security first — injection, auth, secrets, access control — then correctness and scope. The assumption is the agent got it wrong until it's proven right. This is the part that's rare, and accountable.",
+  },
+];
+
+export const offers = [
+  {
+    id: 1,
+    badge: "Start here",
+    title: "Agent-Accelerated Delivery Sprint",
+    body: "A fixed batch of production-ready PRs, each one adversarially reviewed for security, shipped in days at a price you agree before we start.",
+    featured: true,
+  },
+  {
+    id: 2,
+    badge: "",
+    title: "AI-Native Delivery Retainer",
+    body: "A steady flow of security-reviewed PRs every month — agent-speed delivery that runs continuously, not in bursts, with the review layer never dropped.",
+    featured: false,
+  },
+  {
+    id: 3,
+    badge: "",
+    title: "Set Up Your Agent Harness",
+    body: "I install and harden the exact ship/verify harness I run — in your repo, tuned to your stack — so your own team can ship at agent speed with the guardrails already in place.",
+    featured: false,
+  },
+];
+
+export const whoFor = {
+  forList: [
+    "You lead engineering, found a company, or own delivery at a funded startup or scaleup — fintech-adjacent especially.",
+    "You're drowning in backlog and can't hire your way out fast enough.",
+    "You want agent-speed throughput but need a senior human accountable for what merges.",
+    "You'd rather hear the real multiplier than the flattering one.",
+  ],
+  notForList: [
+    "You're shopping purely on hourly rate. The review layer is the value you'd be pricing out.",
+    'You want to hear "100x" and don\'t care who reviews the code.',
+    "You need a staff-aug seat with a badge and standups. This is outcome delivery, not headcount.",
+    "You're pre-idea with no scope to fix a price against.",
+  ],
+};
+
+export const techStackLeft = [
+  "Next.js",
+  "React.js",
+  "Tailwind CSS",
+  "TypeScript",
+];
+
+export const techStackRight = ["SQL", "REST API", "Node.js", "MongoDB"];
 
 export const gridItems = [
   {
@@ -54,7 +123,8 @@ export const gridItems = [
     imgClassName: "",
     titleClassName: "justify-start",
     img: "https://23x7w9tiht.ufs.sh/f/d008b742-3509-47cb-bce0-1312ea498310-1w6rq.svg",
-    spareImg: "https://23x7w9tiht.ufs.sh/f/c1631a06-941c-4f53-94eb-ca026d0cca44-2du.svg",
+    spareImg:
+      "https://23x7w9tiht.ufs.sh/f/c1631a06-941c-4f53-94eb-ca026d0cca44-2du.svg",
   },
 
   {
@@ -65,7 +135,8 @@ export const gridItems = [
     imgClassName: "absolute right-0 bottom-0 md:w-96 w-60",
     titleClassName: "justify-center md:justify-start lg:justify-center",
     img: "https://23x7w9tiht.ufs.sh/f/c4b6c8fd-390f-4dc9-b399-aa6772926947-2dv.svg",
-    spareImg: "https://23x7w9tiht.ufs.sh/f/d008b742-3509-47cb-bce0-1312ea498310-1w6rq.svg",
+    spareImg:
+      "https://23x7w9tiht.ufs.sh/f/d008b742-3509-47cb-bce0-1312ea498310-1w6rq.svg",
   },
   {
     id: 6,
@@ -82,58 +153,59 @@ export const gridItems = [
 export const projects = [
   {
     id: 1,
-    title: 'ShopValue - Product Price Scrapper',
+    title: "ShopValue - Product Price Scrapper",
     description:
-      'Elevate your shopping game with ShopValue. Track prices, spot trends and get the best deals from flip.ro.',
-    img: 'https://utfs.io/a/23x7w9tiht/302c56cd-01cb-4ea4-bf5d-33349de0a959-yg72dh.png',
-    alt: 'ShopValue image',
+      "Elevate your shopping game with ShopValue. Track prices, spot trends and get the best deals from flip.ro.",
+    img: "https://utfs.io/a/23x7w9tiht/302c56cd-01cb-4ea4-bf5d-33349de0a959-yg72dh.png",
+    alt: "ShopValue image",
     iconLists: [
-      'https://utfs.io/a/23x7w9tiht/89882599-3371-4fbc-b4f8-3825ce00e10b-2sz.svg',
-      'https://utfs.io/a/23x7w9tiht/f4808e60-309b-4c54-97b3-86094cd55887-24500.svg',
-      'https://utfs.io/a/23x7w9tiht/926347cb-afd7-4aef-b916-f491fe0b704f-2v3.svg',
-      'https://utfs.io/a/23x7w9tiht/8ee0ad2e-2f9c-4436-8864-b97406507c85-2iv.svg',
+      "https://utfs.io/a/23x7w9tiht/89882599-3371-4fbc-b4f8-3825ce00e10b-2sz.svg",
+      "https://utfs.io/a/23x7w9tiht/f4808e60-309b-4c54-97b3-86094cd55887-24500.svg",
+      "https://utfs.io/a/23x7w9tiht/926347cb-afd7-4aef-b916-f491fe0b704f-2v3.svg",
+      "https://utfs.io/a/23x7w9tiht/8ee0ad2e-2f9c-4436-8864-b97406507c85-2iv.svg",
     ],
     iconListsAlt: [
-      'React icon',
-      'Tailwind CSS icon',
-      'TypeScript icon',
-      'Framer Motion icon',
+      "React icon",
+      "Tailwind CSS icon",
+      "TypeScript icon",
+      "Framer Motion icon",
     ],
     // github: 'https://github.com/AdrianRusan/shop-value',
-    link: 'https://shop-value.vercel.app/',
+    link: "https://shop-value.vercel.app/",
   },
   {
     id: 2,
-    title: 'NextHub - Video Conferencing App',
+    title: "NextHub - Video Conferencing App",
     description:
-      'Simplify your video conferencing experience with NextHub. Seamlessly connect with colleagues and friends.',
-    img: 'https://utfs.io/a/23x7w9tiht/9790aeb2-4bcd-47e7-b2a4-f085489d13d5-2pu.svg',
-    alt: 'NextHub image',
+      "Simplify your video conferencing experience with NextHub. Seamlessly connect with colleagues and friends.",
+    img: "https://utfs.io/a/23x7w9tiht/9790aeb2-4bcd-47e7-b2a4-f085489d13d5-2pu.svg",
+    alt: "NextHub image",
     iconLists: [
-      'https://utfs.io/a/23x7w9tiht/488b9b22-8201-4f04-8ed8-00f38b137785-20eer.svg',
-      'https://utfs.io/a/23x7w9tiht/f4808e60-309b-4c54-97b3-86094cd55887-24500.svg',
-      'https://utfs.io/a/23x7w9tiht/926347cb-afd7-4aef-b916-f491fe0b704f-2v3.svg',
-      'https://utfs.io/a/23x7w9tiht/99f9d107-5657-42a9-8020-4b92baea8f39-er2g00.svg',
-      'https://utfs.io/a/23x7w9tiht/929d0b4c-5f54-485d-b3dd-827509c0c36d-2r.svg',
+      "https://utfs.io/a/23x7w9tiht/488b9b22-8201-4f04-8ed8-00f38b137785-20eer.svg",
+      "https://utfs.io/a/23x7w9tiht/f4808e60-309b-4c54-97b3-86094cd55887-24500.svg",
+      "https://utfs.io/a/23x7w9tiht/926347cb-afd7-4aef-b916-f491fe0b704f-2v3.svg",
+      "https://utfs.io/a/23x7w9tiht/99f9d107-5657-42a9-8020-4b92baea8f39-er2g00.svg",
+      "https://utfs.io/a/23x7w9tiht/929d0b4c-5f54-485d-b3dd-827509c0c36d-2r.svg",
     ],
     iconListsAlt: [
-      'Next.js icon',
-      'Tailwind CSS icon',
-      'TypeScript icon',
-      'GetStream.io icon',
-      'Clerk icon',
+      "Next.js icon",
+      "Tailwind CSS icon",
+      "TypeScript icon",
+      "GetStream.io icon",
+      "Clerk icon",
     ],
-    github: 'https://github.com/AdrianRusan/nexthub',
-    link: 'https://nexthub-project.vercel.app/',
+    github: "https://github.com/AdrianRusan/nexthub",
+    link: "https://nexthub-project.vercel.app/",
   },
 ];
 
 export const testimonials = [
   {
-    quote: "I am very pleased with Adrian's efforts and progress on my project. I was informed on a daily basis about progress, and Adrian is very keen on delivering quality work. He made sure I was happy with the end result, I definitely recommend contacting Adrian if you are in need of any web related projects!",
-    name: 'Tim Claes',
-    title: 'Freelance mobile & Web engineer',
-    img: 'https://utfs.io/a/23x7w9tiht/7iidzn1TwzukCJ59vIyXoxIjwOYaTyPZtGk0mVdeKgr9LH8h',
+    quote:
+      "I am very pleased with Adrian's efforts and progress on my project. I was informed on a daily basis about progress, and Adrian is very keen on delivering quality work. He made sure I was happy with the end result, I definitely recommend contacting Adrian if you are in need of any web related projects!",
+    name: "Tim Claes",
+    title: "Freelance mobile & Web engineer",
+    img: "https://utfs.io/a/23x7w9tiht/7iidzn1TwzukCJ59vIyXoxIjwOYaTyPZtGk0mVdeKgr9LH8h",
   },
 ];
 
@@ -173,43 +245,43 @@ export const companies = [
 export const workExperience = [
   {
     id: 1,
-    title: 'Full Stack Engineer',
-    company: 'Rusan Adrian-Ionuț PFA',
-    period: 'Dec 2022 - Present',
-    desc: 'Built full-stack solutions for fintech apps, web scrapers, video conferencing, and custom dashboards using React, Node.js, and Next.js for diverse client projects.',
-    className: 'md:col-span-2',
+    title: "Full Stack Engineer",
+    company: "Rusan Adrian-Ionuț PFA",
+    period: "Dec 2022 - Present",
+    desc: "Built full-stack solutions for fintech apps, web scrapers, video conferencing, and custom dashboards using React, Node.js, and Next.js for diverse client projects.",
+    className: "md:col-span-2",
     thumbnail:
-      'https://utfs.io/a/23x7w9tiht/5204c033-6bdb-4b06-9c15-7965e18e5561-1v1dh.svg',
+      "https://utfs.io/a/23x7w9tiht/5204c033-6bdb-4b06-9c15-7965e18e5561-1v1dh.svg",
   },
   {
     id: 2,
-    title: 'Full-Stack Engineer',
-    company: 'GoSocial Development SRL',
-    period: 'Sep 2023 - Sep 2024',
-    desc: 'Developed automated web scraping solutions with Puppeteer and built a Facebook Marketing API-integrated dashboard, enhancing data handling efficiency and ad management capabilities.',
-    className: 'md:col-span-2',
+    title: "Full-Stack Engineer",
+    company: "GoSocial Development SRL",
+    period: "Sep 2023 - Sep 2024",
+    desc: "Developed automated web scraping solutions with Puppeteer and built a Facebook Marketing API-integrated dashboard, enhancing data handling efficiency and ad management capabilities.",
+    className: "md:col-span-2",
     thumbnail:
-      'https://utfs.io/a/23x7w9tiht/44cbb969-d079-456a-8554-c62cc61ffb1f-1v1dg.svg',
+      "https://utfs.io/a/23x7w9tiht/44cbb969-d079-456a-8554-c62cc61ffb1f-1v1dg.svg",
   },
   {
     id: 3,
-    title: 'Full Stack Developer',
-    company: 'PGL Esports SRL',
-    period: 'Oct 2020 - Oct 2022',
-    desc: 'Created real-time graphics, interactive leaderboards, and player stats for major esports events, elevating the experience for millions of global fans.',
-    className: 'md:col-span-2',
+    title: "Full Stack Developer",
+    company: "PGL Esports SRL",
+    period: "Oct 2020 - Oct 2022",
+    desc: "Created real-time graphics, interactive leaderboards, and player stats for major esports events, elevating the experience for millions of global fans.",
+    className: "md:col-span-2",
     thumbnail:
-      'https://utfs.io/a/23x7w9tiht/9ae30726-e9a7-43bc-a28c-bce3e44eba67-1v1di.svg',
+      "https://utfs.io/a/23x7w9tiht/9ae30726-e9a7-43bc-a28c-bce3e44eba67-1v1di.svg",
   },
   {
     id: 4,
-    title: 'Frontend Developer',
-    company: 'Ipsos Interactive Services SRL',
-    period: 'Jun 2016 - Sep 2020',
-    desc: 'Delivered over 300 projects of varying complexity for high-profile clients like Google, Coca-Cola, and P&G, ensuring consistent quality and client satisfaction.',
-    className: 'md:col-span-2',
+    title: "Frontend Developer",
+    company: "Ipsos Interactive Services SRL",
+    period: "Jun 2016 - Sep 2020",
+    desc: "Delivered over 300 projects of varying complexity for high-profile clients like Google, Coca-Cola, and P&G, ensuring consistent quality and client satisfaction.",
+    className: "md:col-span-2",
     thumbnail:
-      'https://utfs.io/a/23x7w9tiht/48a6ace0-6271-444c-873a-5cf82e04d3fc-1v1dj.svg',
+      "https://utfs.io/a/23x7w9tiht/48a6ace0-6271-444c-873a-5cf82e04d3fc-1v1dj.svg",
   },
 ];
 
@@ -218,18 +290,18 @@ export const socialMedia = [
     id: 1,
     img: "https://23x7w9tiht.ufs.sh/f/d0acc209-f51b-4737-bf8b-ea1e2d6c55a9-26z6.svg",
     url: "https://github.com/AdrianRusan",
-    alt: "Adrian Rusan GitHub Profile"
+    alt: "Adrian Rusan GitHub Profile",
   },
   {
     id: 2,
-    img: "https://23x7w9tiht.ufs.sh/f/53382907-a497-4b6e-b3b9-92ce21e0be2b-24lbi.svg", 
+    img: "https://23x7w9tiht.ufs.sh/f/53382907-a497-4b6e-b3b9-92ce21e0be2b-24lbi.svg",
     url: "https://twitter.com/adrian_rusan",
-    alt: "Adrian Rusan Twitter Profile"
+    alt: "Adrian Rusan Twitter Profile",
   },
   {
     id: 3,
     img: "https://23x7w9tiht.ufs.sh/f/5d83e728-2f46-4c99-b364-c7fc0ecefe77-1z75m.svg",
     url: "https://linkedin.com/in/adrian-rusan",
-    alt: "Adrian Rusan LinkedIn Profile"
+    alt: "Adrian Rusan LinkedIn Profile",
   },
 ];


### PR DESCRIPTION
## What

Replaces the generic full-stack portfolio homepage with the **AI-native delivery** positioning agreed on: *agents ship the volume, a senior human verifies every PR.* Honest **2-3x**, not 100x. 10+ years in production.

## Page composition (new order)

`Hero → ProofBand → ShipVerify → Offers → CaseStudy → WhoFor → Work Experience → Testimonials → FinalCta → Footer`

Dropped from the homepage: **About**, **Projects** (clone cards), **Approach**.

## New sections

- **ProofBand** — 30 reviewed PRs · 9 batches · 2.5 days; 3 shell-injection vulns caught; 10+ yrs Ipsos → PGL → GoSocial → Bono.
- **ShipVerify** (`#ship-verify`) — the problem framing + the two-step (SHIP / VERIFY).
- **Offers** (`#offers`) — three engagements; the Delivery Sprint is the featured entry point.
- **CaseStudy** (`#work`) — 30 PRs / 3 vulnerabilities teaser → `/blog/30-prs-in-2-5-days`.
- **WhoFor** — qualifies the buyer (for / not-for).
- **FinalCta** — honest scarcity (verify layer doesn't parallelize).

Nav updated: How it works → `#ship-verify`, Services → `#offers`, Work → `#work`, Blog → `/blog`, Contact → `#contact`. All CTAs route to `#contact` (Footer) pending a real booking link.

## Verification

- `tsc --noEmit`: no new errors (pre-existing blog/MDX/e2e errors untouched).
- Dev server: full page renders end-to-end, no console errors, every anchor (`#ship-verify` / `#offers` / `#work` / `#contact`) resolves.

## Follow-ups (not in this PR)

- Supply a real booking link to replace `#contact`.
- Dedicated `/services`, `/work`, `/about`, `/contact` routes.
- Footer copyright still reads 2024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)