### PR TITLE
feat: add /services offer page

### DIFF
--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { FloatingNav } from "@/components/ui/FloatingNav";
+import { ServicesHero } from "@/components/services/ServicesHero";
+import { ProcessSteps } from "@/components/services/ProcessSteps";
+import { DeliverySprint } from "@/components/services/DeliverySprint";
+import { Retainer } from "@/components/services/Retainer";
+import { HarnessSetup } from "@/components/services/HarnessSetup";
+import { Scarcity } from "@/components/services/Scarcity";
+import { ServicesFaq } from "@/components/services/ServicesFaq";
+import { ServicesFinalCta } from "@/components/services/ServicesFinalCta";
+
+export const metadata: Metadata = {
+  title:
+    "Services — Agent-Accelerated Delivery Sprints, Reviewed | Adrian Rusan",
+  description:
+    "Fixed-scope, fixed-price sprints: an agent fleet ships the volume, a senior engineer security-reviews every PR before you see it. 30 reviewed PRs in 2.5 days.",
+  openGraph: {
+    title:
+      "Services — Agent-Accelerated Delivery Sprints, Reviewed | Adrian Rusan",
+    description:
+      "Fixed-scope, fixed-price sprints: an agent fleet ships the volume, a senior engineer security-reviews every PR before you see it. 30 reviewed PRs in 2.5 days.",
+    type: "website",
+  },
+  alternates: {
+    canonical: "/services",
+  },
+};
+
+const servicesNavItems = [
+  { name: "Home", link: "/" },
+  { name: "How it works", link: "#process" },
+  { name: "Work", link: "/#work" },
+  { name: "Blog", link: "/blog" },
+  { name: "Contact", link: "/#contact" },
+];
+
+export default function ServicesPage() {
+  return (
+    <main className="relative dark:bg-black-100 bg-white overflow-hidden">
+      <FloatingNav navItems={servicesNavItems} />
+      <ServicesHero />
+      <ProcessSteps />
+      <DeliverySprint />
+      <Retainer />
+      <HarnessSetup />
+      <Scarcity />
+      <ServicesFaq />
+      <ServicesFinalCta />
+    </main>
+  );
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -3,6 +3,7 @@ import { FloatingNav } from "@/components/ui/FloatingNav";
 import { ServicesHero } from "@/components/services/ServicesHero";
 import { ProcessSteps } from "@/components/services/ProcessSteps";
 import { DeliverySprint } from "@/components/services/DeliverySprint";
+import { TrustStrip } from "@/components/services/TrustStrip";
 import { Retainer } from "@/components/services/Retainer";
 import { HarnessSetup } from "@/components/services/HarnessSetup";
 import { Scarcity } from "@/components/services/Scarcity";
@@ -41,6 +42,7 @@ export default function ServicesPage() {
       <ServicesHero />
       <ProcessSteps />
       <DeliverySprint />
+      <TrustStrip />
       <Retainer />
       <HarnessSetup />
       <Scarcity />

--- a/components/CaseStudy.tsx
+++ b/components/CaseStudy.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { CALENDLY_URL } from "@/data";
 
 const CaseStudy = () => {
   return (
@@ -27,7 +28,9 @@ const CaseStudy = () => {
           </Link>
           <span className="text-white-200/40">·</span>
           <a
-            href="#contact"
+            href={CALENDLY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
             className="text-sm font-medium text-blue-100 hover:text-purple transition-colors"
           >
             Run this on your backlog

--- a/components/FinalCta.tsx
+++ b/components/FinalCta.tsx
@@ -1,5 +1,6 @@
 import MagicButton from "./ui/MagicButton";
 import { FaLocationArrow } from "react-icons/fa6";
+import { CALENDLY_URL } from "@/data";
 
 const FinalCta = () => {
   return (
@@ -16,13 +17,12 @@ const FinalCta = () => {
           You triage and merge. I&apos;m accountable for what lands.
         </p>
         <div className="flex justify-center mt-8">
-          <a href="#contact" aria-label="Book a scoping call">
-            <MagicButton
-              title="Book a scoping call"
-              icon={<FaLocationArrow />}
-              position="right"
-            />
-          </a>
+          <MagicButton
+            title="Book a scoping call"
+            icon={<FaLocationArrow />}
+            position="right"
+            href={CALENDLY_URL}
+          />
         </div>
         <p className="text-xs text-white-200/60 mt-6 max-w-xl mx-auto">
           The verify layer is one senior human and doesn&apos;t parallelize — so

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -3,6 +3,7 @@ import MagicButton from "./ui/MagicButton";
 import { TextGenerateEffect } from "./ui/TextGenerateEffect";
 import { FaLocationArrow } from "react-icons/fa6";
 import SpotlightBackground from "./ui/SpotlightBackground";
+import { CALENDLY_URL } from "@/data";
 
 const Hero = () => {
   return (
@@ -40,15 +41,14 @@ const Hero = () => {
           </p>
 
           <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 mt-2">
-            <a href="#contact" aria-label="Book a scoping call">
-              <MagicButton
-                title="Book a scoping call"
-                icon={<FaLocationArrow />}
-                position="right"
-              />
-            </a>
+            <MagicButton
+              title="Book a scoping call"
+              icon={<FaLocationArrow />}
+              position="right"
+              href={CALENDLY_URL}
+            />
             <a
-              href="#offers"
+              href="/services"
               className="text-sm font-medium text-blue-100 hover:text-purple transition-colors md:mt-10"
             >
               See how the sprint works →

--- a/components/Offers.tsx
+++ b/components/Offers.tsx
@@ -30,7 +30,7 @@ const Offers = () => {
                 {offer.body}
               </p>
               <a
-                href="#contact"
+                href="/services"
                 className="text-sm font-medium text-purple hover:underline underline-offset-4 mt-5"
               >
                 Learn more →

--- a/components/services/DeliverySprint.tsx
+++ b/components/services/DeliverySprint.tsx
@@ -1,0 +1,192 @@
+import MagicButton from "@/components/ui/MagicButton";
+import { FaLocationArrow } from "react-icons/fa6";
+import { PricingTable } from "./PricingTable";
+import type { PricingColumn, PricingRow } from "./PricingTable";
+
+const deliverables = [
+  {
+    lead: "A fixed number of merge-ready PRs,",
+    rest: "on real branches in your repo, reviewed and green — ready for your team's final merge.",
+  },
+  {
+    lead: "A per-PR review note:",
+    rest: "what the agent produced, what the review caught and changed, and the residual risk, if any.",
+  },
+  {
+    lead: "A security findings log for the whole sprint",
+    rest: "— every vulnerability class checked, everything caught and fixed, stated plainly. This is the artifact the sprint is selling.",
+  },
+  {
+    lead: "A sprint wrap doc:",
+    rest: "what shipped, what's left, and what the agents consistently got wrong in your codebase — a useful map for your team going forward.",
+  },
+];
+
+const notList = [
+  "Not open-ended. The PR count and scope are fixed on day 0. New scope is a new sprint, not a moving target.",
+  "Not a staff-augmentation seat. You're buying reviewed outcomes, not a body for standups.",
+  "Not greenfield architecture from zero. Designing a new system from scratch is a separate conversation.",
+  "Not an auto-merge to production. I deliver reviewed, green, merge-ready PRs. The final merge and deploy decision stays with your team — deliberately, so your change control stays intact.",
+  "Not ongoing maintenance. On-call and upkeep after handoff live in the retainer.",
+];
+
+const columns: PricingColumn[] = [
+  { name: "Pilot Sprint" },
+  { name: "Standard Sprint", badge: "Recommended", featured: true },
+  { name: "Scale Sprint" },
+];
+
+const rows: PricingRow[] = [
+  {
+    label: "Best for",
+    values: [
+      "A low-risk first engagement — testing the working relationship",
+      "A senior contractor-month of output, reviewed, in two weeks",
+      "A larger surface, more PRs, more review depth",
+    ],
+  },
+  {
+    label: "Roughly",
+    values: [
+      "~5–8 reviewed PRs",
+      "~10–15 reviewed PRs",
+      "~16–20+ reviewed PRs",
+    ],
+  },
+  {
+    label: "Timeline",
+    values: ["~3–5 days", "~1–2 weeks", "~2–3 weeks"],
+  },
+  {
+    label: "Price",
+    values: [
+      "from €4,000",
+      "Quoted after scope call",
+      "Quoted after scope call",
+    ],
+  },
+];
+
+export const DeliverySprint = () => {
+  return (
+    <section id="sprint" className="px-5 sm:px-10 py-20">
+      <div className="max-w-6xl mx-auto">
+        <div className="relative rounded-2xl border border-purple shadow-[inset_0_0_0_1px_#CBACF9] bg-black-200/40 p-6 md:p-10">
+          <span className="absolute -top-3 left-6 md:left-10 font-mono text-[10px] font-bold uppercase tracking-[0.1em] text-purple bg-black-100 px-3 py-1 rounded-full border border-purple">
+            Most teams start here
+          </span>
+
+          <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-purple mt-4 block">
+            Primary offer
+          </span>
+          <h2 className="text-2xl md:text-4xl font-bold tracking-tight mt-3 text-balance">
+            Agent-Accelerated Delivery Sprint
+          </h2>
+          <p className="text-white-200 mt-5 leading-relaxed max-w-3xl">
+            A fixed batch of production-ready, security-reviewed pull requests —
+            shipped by an agent fleet, verified line by line by a senior
+            engineer — delivered in days, at a price you agree before we start.
+          </p>
+
+          <h3 className="text-lg font-semibold mt-10 mb-4">
+            Exactly what&apos;s delivered
+          </h3>
+          <ul className="flex flex-col gap-3">
+            {deliverables.map((item) => (
+              <li
+                key={item.lead}
+                className="flex gap-3 text-sm text-white-200 leading-relaxed"
+              >
+                <span className="text-purple flex-none">+</span>
+                <span>
+                  <span className="text-white font-medium">{item.lead}</span>{" "}
+                  {item.rest}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <h3 className="text-lg font-semibold mt-10 mb-4">Pricing</h3>
+          <PricingTable
+            columns={columns}
+            rows={rows}
+            ctaHref="/#contact"
+            ctaLabel="Book a scoping call"
+          />
+          <p className="text-xs text-white-200/70 mt-4 italic">
+            Every sprint is priced on the reviewed outcome, not hours logged.
+            The exact number is fixed on the scope call, before any work starts.
+          </p>
+
+          <h3 className="text-lg font-semibold mt-10 mb-2">What this is NOT</h3>
+          <p className="text-sm text-white-200/70 mb-4">
+            Being clear up front saves us both a bad-fit call.
+          </p>
+          <ul className="flex flex-col gap-3">
+            {notList.map((item) => (
+              <li
+                key={item}
+                className="flex gap-3 text-sm text-white-200/80 leading-relaxed"
+              >
+                <span className="text-white-200/40 flex-none">−</span>
+                {item}
+              </li>
+            ))}
+          </ul>
+
+          <h3 className="text-lg font-semibold mt-10 mb-4">The guarantees</h3>
+          <p className="text-sm text-white-200/70 mb-4">
+            Two, both concrete and checkable. No &quot;double your revenue or
+            your money back&quot; theatre.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+            <div className="rounded-xl border border-white/10 bg-black-200/30 p-5">
+              <p className="font-mono text-xs text-purple mb-2">
+                1. Security guarantee
+              </p>
+              <p className="text-sm text-white-200 leading-relaxed">
+                Every delivered PR passes a documented adversarial security
+                review before you see it. If a vulnerability that was in scope
+                of that review is later found in a PR I marked reviewed, I fix
+                it free and re-review the surrounding batch at no charge.
+              </p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-black-200/30 p-5">
+              <p className="font-mono text-xs text-purple mb-2">
+                2. First-PR proof guarantee
+              </p>
+              <p className="text-sm text-white-200 leading-relaxed">
+                The first reviewed PR lands within 48 hours of repo access. If
+                it doesn&apos;t, that sprint is 25% off — no argument. Your risk
+                is highest before I&apos;ve shipped anything, so the guarantee
+                sits right there.
+              </p>
+            </div>
+          </div>
+          <p className="text-xs text-white-200/60 mt-4 max-w-2xl">
+            There is deliberately no blanket &quot;money back if unhappy&quot;
+            guarantee. It invites scope disputes and it&apos;s not how a senior
+            operator works. These two put my skin in the game where it actually
+            matters: speed and security.
+          </p>
+
+          <h3 className="text-lg font-semibold mt-10 mb-2">Payment</h3>
+          <p className="text-sm text-white-200 leading-relaxed max-w-2xl">
+            50% to book the slot, 50% on handoff. A Pilot Sprint can be paid
+            100% up front given the small ticket. Running multiple sprints?
+            That&apos;s the retainer, below.
+          </p>
+
+          <div className="mt-8">
+            <MagicButton
+              title="Book a scoping call"
+              icon={<FaLocationArrow />}
+              position="right"
+              href="/#contact"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/services/DeliverySprint.tsx
+++ b/components/services/DeliverySprint.tsx
@@ -1,4 +1,5 @@
 import MagicButton from "@/components/ui/MagicButton";
+import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 import { PricingTable } from "./PricingTable";
 import type { PricingColumn, PricingRow } from "./PricingTable";
@@ -110,7 +111,7 @@ export const DeliverySprint = () => {
           <PricingTable
             columns={columns}
             rows={rows}
-            ctaHref="/#contact"
+            ctaHref={CALENDLY_URL}
             ctaLabel="Book a scoping call"
           />
           <p className="text-xs text-white-200/70 mt-4 italic">
@@ -182,7 +183,7 @@ export const DeliverySprint = () => {
               title="Book a scoping call"
               icon={<FaLocationArrow />}
               position="right"
-              href="/#contact"
+              href={CALENDLY_URL}
             />
           </div>
         </div>

--- a/components/services/DeliverySprint.tsx
+++ b/components/services/DeliverySprint.tsx
@@ -48,7 +48,7 @@ const rows: PricingRow[] = [
   {
     label: "Roughly",
     values: [
-      "~5–8 reviewed PRs",
+      "~5–6 reviewed PRs",
       "~10–15 reviewed PRs",
       "~16–20+ reviewed PRs",
     ],
@@ -60,9 +60,9 @@ const rows: PricingRow[] = [
   {
     label: "Price",
     values: [
-      "from €4,000",
-      "Quoted after scope call",
-      "Quoted after scope call",
+      "from €7,500",
+      "from €14,500",
+      "from €24,000 — scoped after a 30-min assessment",
     ],
   },
 ];

--- a/components/services/HarnessSetup.tsx
+++ b/components/services/HarnessSetup.tsx
@@ -19,21 +19,27 @@ const terms = [
 ];
 
 const columns: PricingColumn[] = [
-  { name: "Harness Setup" },
-  { name: "Harness Setup + Enablement", badge: "Recommended", featured: true },
+  { name: "Install" },
+  { name: "Install + Enablement", badge: "Recommended", featured: true },
+  { name: "Fleet Rollout" },
 ];
 
 const rows: PricingRow[] = [
   {
     label: "Scope",
     values: [
-      "Configure + one live batch + playbook + 2 weeks support",
-      "Everything in Setup, plus multi-session team enablement until they ship solo",
+      "One repo: agent fleet config, CI security gates, review rubric + runbook. ~1 week.",
+      "Everything in Install, plus 2–3 workshops, tuned review rubrics, methodology transfer, 30 days support. ~2 weeks.",
+      "Multi-repo / org-wide standards, embedded pairing, security-gate policy across services, advisory handoff.",
     ],
   },
   {
     label: "Price",
-    values: ["Quoted after scope call", "Quoted after scope call"],
+    values: [
+      "from €9,000",
+      "from €18,000",
+      "from €30,000 — scoped after assessment",
+    ],
   },
 ];
 

--- a/components/services/HarnessSetup.tsx
+++ b/components/services/HarnessSetup.tsx
@@ -1,0 +1,115 @@
+import MagicButton from "@/components/ui/MagicButton";
+import { FaLocationArrow } from "react-icons/fa6";
+import { PricingTable } from "./PricingTable";
+import type { PricingColumn, PricingRow } from "./PricingTable";
+
+const deliverables = [
+  "A working Claude Code agent harness configured against your repo: CLAUDE.md project rules, the worktree and dispatch workflow, and CI wiring.",
+  "The adversarial security review checklist I use — the artifact that caught 3 real shell-injection vulnerabilities that passed automated tests — adapted to your stack and handed over as yours to keep.",
+  "A hands-on working session (or short series): I run a live batch against your backlog with your team watching, then your team runs the next batch with me reviewing.",
+  "A written playbook: how to dispatch, what to review first, the failure modes to expect in your codebase, and where the human verify layer is non-negotiable.",
+  "2 weeks of async follow-up support after handover as your team adopts it.",
+];
+
+const terms = [
+  "This is setup and enablement, not ongoing delivery. Want delivery too? That's the sprint or the retainer.",
+  "Requires your team present and participating — this is assistive by design, not done-for-you. Said plainly so expectations match.",
+  "Doesn't include Claude Code licenses or third-party tool seats — you bring your own accounts.",
+  "The harness is configured and handed over; I don't retain access unless you add a retainer.",
+];
+
+const columns: PricingColumn[] = [
+  { name: "Harness Setup" },
+  { name: "Harness Setup + Enablement", badge: "Recommended", featured: true },
+];
+
+const rows: PricingRow[] = [
+  {
+    label: "Scope",
+    values: [
+      "Configure + one live batch + playbook + 2 weeks support",
+      "Everything in Setup, plus multi-session team enablement until they ship solo",
+    ],
+  },
+  {
+    label: "Price",
+    values: ["Quoted after scope call", "Quoted after scope call"],
+  },
+];
+
+export const HarnessSetup = () => {
+  return (
+    <section className="px-5 sm:px-10 py-20">
+      <div className="max-w-6xl mx-auto rounded-2xl border border-white/10 bg-black-200/40 p-6 md:p-10">
+        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-blue-100">
+          Teach your team to fish
+        </span>
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight mt-3 text-balance">
+          Set Up Your Agent Harness
+        </h2>
+        <p className="text-white-200 mt-5 leading-relaxed max-w-3xl">
+          I install and harden the exact ship/verify agent harness I run — in
+          your repo, tuned to your stack and conventions — so your own team can
+          ship at agent speed with the safety rails already in place.
+        </p>
+
+        <h3 className="text-lg font-semibold mt-10 mb-4">
+          Exactly what&apos;s delivered
+        </h3>
+        <ul className="flex flex-col gap-3">
+          {deliverables.map((item) => (
+            <li
+              key={item}
+              className="flex gap-3 text-sm text-white-200 leading-relaxed"
+            >
+              <span className="text-purple flex-none">+</span>
+              {item}
+            </li>
+          ))}
+        </ul>
+
+        <h3 className="text-lg font-semibold mt-10 mb-4">Pricing</h3>
+        <PricingTable
+          columns={columns}
+          rows={rows}
+          ctaHref="/#contact"
+          ctaLabel="Book a scoping call"
+        />
+
+        <h3 className="text-lg font-semibold mt-10 mb-4">Terms</h3>
+        <ul className="flex flex-col gap-3">
+          {terms.map((item) => (
+            <li
+              key={item}
+              className="flex gap-3 text-sm text-white-200/80 leading-relaxed"
+            >
+              <span className="text-white-200/40 flex-none">−</span>
+              {item}
+            </li>
+          ))}
+        </ul>
+
+        <h3 className="text-lg font-semibold mt-10 mb-2">Guarantee</h3>
+        <p className="text-sm text-white-200 leading-relaxed max-w-2xl">
+          <span className="text-purple font-medium">
+            Working-harness guarantee.
+          </span>{" "}
+          By the end of the engagement, your team has shipped at least one
+          reviewed PR through the harness themselves — live, with me present. If
+          they haven&apos;t, the enablement sessions continue at no extra charge
+          until they have. The outcome is &quot;your team did it,&quot; not
+          &quot;your team watched it done.&quot;
+        </p>
+
+        <div className="mt-8">
+          <MagicButton
+            title="Book a scoping call"
+            icon={<FaLocationArrow />}
+            position="right"
+            href="/#contact"
+          />
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/services/HarnessSetup.tsx
+++ b/components/services/HarnessSetup.tsx
@@ -1,4 +1,5 @@
 import MagicButton from "@/components/ui/MagicButton";
+import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 import { PricingTable } from "./PricingTable";
 import type { PricingColumn, PricingRow } from "./PricingTable";
@@ -78,7 +79,7 @@ export const HarnessSetup = () => {
         <PricingTable
           columns={columns}
           rows={rows}
-          ctaHref="/#contact"
+          ctaHref={CALENDLY_URL}
           ctaLabel="Book a scoping call"
         />
 
@@ -112,7 +113,7 @@ export const HarnessSetup = () => {
             title="Book a scoping call"
             icon={<FaLocationArrow />}
             position="right"
-            href="/#contact"
+            href={CALENDLY_URL}
           />
         </div>
       </div>

--- a/components/services/PricingTable.tsx
+++ b/components/services/PricingTable.tsx
@@ -82,7 +82,13 @@ export const PricingTable = ({
                 key={column.name}
                 className={`py-6 px-4 ${column.featured ? "bg-black-200/60" : ""}`}
               >
-                <Link href={ctaHref} aria-label={ctaLabel}>
+                <Link
+                  href={ctaHref}
+                  aria-label={ctaLabel}
+                  {...(ctaHref.startsWith("http")
+                    ? { target: "_blank", rel: "noopener noreferrer" }
+                    : {})}
+                >
                   <span className="inline-flex items-center rounded-lg border border-purple/40 px-4 py-2 text-xs font-medium text-purple hover:bg-purple/10 transition-colors">
                     {ctaLabel}
                   </span>

--- a/components/services/PricingTable.tsx
+++ b/components/services/PricingTable.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+
+export interface PricingColumn {
+  name: string;
+  badge?: string;
+  featured?: boolean;
+}
+
+export interface PricingRow {
+  label: string;
+  values: string[];
+}
+
+export interface PricingTableProps {
+  columns: PricingColumn[];
+  rows: PricingRow[];
+  ctaHref: string;
+  ctaLabel: string;
+}
+
+export const PricingTable = ({
+  columns,
+  rows,
+  ctaHref,
+  ctaLabel,
+}: PricingTableProps) => {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[560px] border-collapse text-sm">
+        <thead>
+          <tr>
+            <th className="text-left align-bottom pb-4 pr-4 w-1/4" />
+            {columns.map((column) => (
+              <th
+                key={column.name}
+                className={`text-left align-bottom pb-4 px-4 border-b ${
+                  column.featured
+                    ? "border-purple bg-black-200/60"
+                    : "border-white/10"
+                }`}
+              >
+                {column.badge && (
+                  <span className="block font-mono text-[10px] font-bold uppercase tracking-[0.1em] text-purple mb-1">
+                    {column.badge}
+                  </span>
+                )}
+                <span className="text-base font-semibold text-white">
+                  {column.name}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label} className="border-b border-white/10">
+              <th
+                scope="row"
+                className="text-left align-top py-4 pr-4 font-medium text-white-200 whitespace-nowrap"
+              >
+                {row.label}
+              </th>
+              {row.values.map((value, index) => {
+                const column = columns[index];
+                return (
+                  <td
+                    key={`${row.label}-${column?.name ?? index}`}
+                    className={`align-top py-4 px-4 text-white-200 leading-relaxed ${
+                      column?.featured ? "bg-black-200/60" : ""
+                    }`}
+                  >
+                    {value}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+          <tr>
+            <td className="py-6 pr-4" />
+            {columns.map((column) => (
+              <td
+                key={column.name}
+                className={`py-6 px-4 ${column.featured ? "bg-black-200/60" : ""}`}
+              >
+                <Link href={ctaHref} aria-label={ctaLabel}>
+                  <span className="inline-flex items-center rounded-lg border border-purple/40 px-4 py-2 text-xs font-medium text-purple hover:bg-purple/10 transition-colors">
+                    {ctaLabel}
+                  </span>
+                </Link>
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/components/services/ProcessSteps.tsx
+++ b/components/services/ProcessSteps.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+interface ProcessStep {
+  tag: string;
+  heading: string;
+  body: ReactNode;
+  caption?: string;
+}
+
+const steps: ProcessStep[] = [
+  {
+    tag: "1 · SCOPE",
+    heading: "Scope call (day 0)",
+    body: "We agree the PR batch, the definition of done for each item, repo access, and your conventions. Fixed scope and fixed price are locked here. This is also the sales conversation — if it's not a fit, you'll know on the call.",
+  },
+  {
+    tag: "2 · SHIP",
+    heading: "The agent fleet (days 1–N)",
+    body: "Tickets get dispatched to parallel Claude Code agents running in isolated git worktrees, driven by your CLAUDE.md conventions. This is where the volume comes from, and where the 2-3x lives.",
+    caption: "~2-3x throughput",
+  },
+  {
+    tag: "3 · VERIFY",
+    heading: "Senior adversarial review (continuous)",
+    body: (
+      <>
+        Every agent PR goes through my review layer before it&apos;s offered to
+        you. Security first — injection, auth, secrets, access control — then
+        correctness and scope. I assume the agent got it wrong until it&apos;s
+        proven right. This is the part that doesn&apos;t scale with more agents,
+        and it&apos;s the whole reason this service exists.{" "}
+        <Link
+          href="/#ship-verify"
+          className="text-purple hover:underline underline-offset-4"
+        >
+          Read how the review layer works in depth →
+        </Link>
+      </>
+    ),
+    caption: "does not parallelize — one senior human",
+  },
+  {
+    tag: "4 · HANDOFF",
+    heading: "Handoff (final day)",
+    body: "You get the reviewed PRs on real branches in your repo, a security findings log for the whole sprint, and a wrap doc covering what shipped and what the agents consistently got wrong in your codebase. You triage and merge.",
+  },
+];
+
+export const ProcessSteps = () => {
+  return (
+    <section id="process" className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-balance">
+          How the work actually runs
+        </h2>
+        <p className="text-white-200 mt-4 max-w-2xl leading-relaxed">
+          Four steps. The scope and price are locked on day 0, so there&apos;s
+          no runaway bill — and no PR reaches you without a senior review behind
+          it.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-px bg-white/10 border border-white/10 rounded-xl overflow-hidden mt-10">
+          {steps.map((step) => (
+            <div
+              key={step.tag}
+              className={`p-6 flex flex-col ${
+                step.tag.includes("VERIFY")
+                  ? "bg-black-200/60 border-t-2 md:border-t-0 md:border-l-2 border-purple"
+                  : "bg-black-200/30"
+              }`}
+            >
+              <span
+                className={`font-mono text-[11px] font-bold tracking-[0.1em] ${
+                  step.tag.includes("VERIFY") ? "text-purple" : "text-blue-100"
+                }`}
+              >
+                {step.tag}
+              </span>
+              <h3 className="text-base font-semibold mt-2 mb-2">
+                {step.heading}
+              </h3>
+              <p className="text-sm text-white-200 leading-relaxed flex-1">
+                {step.body}
+              </p>
+              {step.caption && (
+                <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-white-200/60 mt-4">
+                  {step.caption}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <p className="text-center text-white font-medium mt-8 border border-white/10 rounded-xl py-4 bg-black-200/40">
+          Nothing reaches you unreviewed. That&apos;s the contract.
+        </p>
+      </div>
+    </section>
+  );
+};

--- a/components/services/Retainer.tsx
+++ b/components/services/Retainer.tsx
@@ -26,18 +26,14 @@ const rows: PricingRow[] = [
   {
     label: "Roughly",
     values: [
-      "~8–12 reviewed PRs/mo",
-      "~15–20 reviewed PRs/mo",
-      "~25+ reviewed PRs/mo, priority verify",
+      "~6–8 reviewed PRs/mo",
+      "~12–15 reviewed PRs/mo",
+      "~20+ reviewed PRs/mo, dedicated",
     ],
   },
   {
     label: "Price",
-    values: [
-      "Quoted after scope call",
-      "Quoted after scope call",
-      "Quoted after scope call",
-    ],
+    values: ["from €7,000/mo", "from €12,000/mo", "from €22,000/mo — 1 slot"],
   },
 ];
 

--- a/components/services/Retainer.tsx
+++ b/components/services/Retainer.tsx
@@ -1,4 +1,5 @@
 import MagicButton from "@/components/ui/MagicButton";
+import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 import { PricingTable } from "./PricingTable";
 import type { PricingColumn, PricingRow } from "./PricingTable";
@@ -72,7 +73,7 @@ export const Retainer = () => {
         <PricingTable
           columns={columns}
           rows={rows}
-          ctaHref="/#contact"
+          ctaHref={CALENDLY_URL}
           ctaLabel="Book a scoping call"
         />
 
@@ -94,7 +95,7 @@ export const Retainer = () => {
             title="Book a scoping call"
             icon={<FaLocationArrow />}
             position="right"
-            href="/#contact"
+            href={CALENDLY_URL}
           />
         </div>
       </div>

--- a/components/services/Retainer.tsx
+++ b/components/services/Retainer.tsx
@@ -1,0 +1,107 @@
+import MagicButton from "@/components/ui/MagicButton";
+import { FaLocationArrow } from "react-icons/fa6";
+import { PricingTable } from "./PricingTable";
+import type { PricingColumn, PricingRow } from "./PricingTable";
+
+const deliverables = [
+  "A committed monthly PR throughput band, all adversarially reviewed — the same ship/verify pipeline as the sprint, on a continuous cadence.",
+  'A rolling security findings log and a monthly "what the agents got wrong in your codebase" report.',
+  "Standing async access to me for delivery and review questions.",
+  "Priority booking over one-off sprints — retainer clients hold a permanent verify slot.",
+];
+
+const terms = [
+  "Throughput is a band, not unlimited. Overflow rolls to the next month or a top-up sprint.",
+  "Not 24/7 on-call incident response — that can be added as a named line item, priced separately.",
+  "Month-to-month after an initial 3-month commitment. Cancel anytime after that with 30 days' notice. Long enough to prove it works, short enough to be honest. No lock-in beyond the proof period.",
+];
+
+const columns: PricingColumn[] = [
+  { name: "Steady" },
+  { name: "Core", badge: "Recommended", featured: true },
+  { name: "Embedded" },
+];
+
+const rows: PricingRow[] = [
+  {
+    label: "Roughly",
+    values: [
+      "~8–12 reviewed PRs/mo",
+      "~15–20 reviewed PRs/mo",
+      "~25+ reviewed PRs/mo, priority verify",
+    ],
+  },
+  {
+    label: "Price",
+    values: [
+      "Quoted after scope call",
+      "Quoted after scope call",
+      "Quoted after scope call",
+    ],
+  },
+];
+
+export const Retainer = () => {
+  return (
+    <section className="px-5 sm:px-10 py-20">
+      <div className="max-w-6xl mx-auto rounded-2xl border border-white/10 bg-black-200/40 p-6 md:p-10">
+        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-blue-100">
+          Ongoing capacity
+        </span>
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight mt-3 text-balance">
+          AI-Native Delivery Retainer
+        </h2>
+        <p className="text-white-200 mt-5 leading-relaxed max-w-3xl">
+          Senior AI-native delivery, every month: a committed flow of
+          security-reviewed PRs for teams who&apos;ve stopped asking whether
+          agents are fast and now want them running continuously and safely.
+        </p>
+
+        <h3 className="text-lg font-semibold mt-10 mb-4">
+          What&apos;s delivered, monthly
+        </h3>
+        <ul className="flex flex-col gap-3">
+          {deliverables.map((item) => (
+            <li
+              key={item}
+              className="flex gap-3 text-sm text-white-200 leading-relaxed"
+            >
+              <span className="text-purple flex-none">+</span>
+              {item}
+            </li>
+          ))}
+        </ul>
+
+        <h3 className="text-lg font-semibold mt-10 mb-4">Pricing</h3>
+        <PricingTable
+          columns={columns}
+          rows={rows}
+          ctaHref="/#contact"
+          ctaLabel="Book a scoping call"
+        />
+
+        <h3 className="text-lg font-semibold mt-10 mb-4">Terms</h3>
+        <ul className="flex flex-col gap-3">
+          {terms.map((item) => (
+            <li
+              key={item}
+              className="flex gap-3 text-sm text-white-200/80 leading-relaxed"
+            >
+              <span className="text-white-200/40 flex-none">−</span>
+              {item}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-8">
+          <MagicButton
+            title="Book a scoping call"
+            icon={<FaLocationArrow />}
+            position="right"
+            href="/#contact"
+          />
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/services/Scarcity.tsx
+++ b/components/services/Scarcity.tsx
@@ -1,0 +1,45 @@
+export const Scarcity = () => {
+  return (
+    <section className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-balance">
+          Why I can only run a few of these at once
+        </h2>
+        <p className="text-white-200 mt-5 leading-relaxed max-w-3xl">
+          The verify layer is one senior human — me — and it does not
+          parallelize. Agents scale the shipping; the review does not.
+          That&apos;s not a marketing constraint, it&apos;s the actual
+          bottleneck of the model, and it&apos;s the reason the whole thing is
+          safe to merge.
+        </p>
+        <p className="text-white-200 mt-4 leading-relaxed max-w-3xl">
+          So here&apos;s how the capacity actually works:
+        </p>
+        <ul className="flex flex-col gap-3 mt-4">
+          <li className="flex gap-3 text-sm text-white-200 leading-relaxed">
+            <span className="text-purple flex-none">+</span>
+            <span>
+              <span className="text-white font-medium">
+                Currently 2 Delivery Sprints run at a time.
+              </span>{" "}
+              When both slots are taken, new engagements join a dated waitlist.
+            </span>
+          </li>
+          <li className="flex gap-3 text-sm text-white-200 leading-relaxed">
+            <span className="text-purple flex-none">+</span>
+            <span>
+              <span className="text-white font-medium">
+                Retainers hold a permanent verify slot,
+              </span>{" "}
+              so only a couple run alongside the sprints at any time.
+            </span>
+          </li>
+        </ul>
+        <p className="text-white-200/80 mt-6 max-w-3xl leading-relaxed">
+          No countdown timers, no &quot;3 spots left today.&quot; The scarcity
+          is just the truth about how this works — and it&apos;s also the pitch.
+        </p>
+      </div>
+    </section>
+  );
+};

--- a/components/services/ServicesFaq.tsx
+++ b/components/services/ServicesFaq.tsx
@@ -1,0 +1,65 @@
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+const faqItems: FaqItem[] = [
+  {
+    question: "How is the quality any good if AI agents wrote it?",
+    answer:
+      "Because agent output is the draft, not the deliverable. Every PR goes through a line-by-line senior review that assumes the agent got it wrong until it's proven right — the same review a strong senior gives a junior's PR, at agent speed. Agents give you 2-3x throughput, not 100x, and they get specific things wrong. The review layer is where those get caught, and every sprint ships you a log of exactly what got caught in your codebase.",
+  },
+  {
+    question:
+      "I'm specifically worried about security. Unsupervised agents ship vulnerabilities.",
+    answer:
+      'Correct — they do. That\'s the reason this service exists instead of a cheaper "just run the agents" option. Real example: the adversarial review has caught 3 shell-injection vulnerabilities the agents wrote that passed the automated tests. Security is the first pass of every review, and you get a written findings log for the whole sprint. The security guarantee is in writing: an in-scope vulnerability found in a PR I marked reviewed gets fixed free.',
+  },
+  {
+    question: "Why not just hire an agency, or more engineers?",
+    answer:
+      "An agency sells you a team's hours and marks them up; more headcount takes months to hire and ramp. This sells you reviewed outcomes in days, from one senior operator running an agent fleet — no coordination overhead, no ramp, no junior work billed at senior rates. And the real gap: an agency using agents rarely has a senior adversarial verify layer sitting on top. That layer is the whole point here, not an add-on.",
+  },
+  {
+    question: "Who owns the code, and how is confidentiality handled?",
+    answer:
+      "You own everything — your repo, your branches, your IP, from the first commit. Work happens in your repository under your access controls. I sign your NDA or DPA before repo access; access is revoked at handoff unless you're on a retainer. No client code is used to train anything or reused anywhere else. For fintech clients, the security review covers secrets handling and access control as standard.",
+  },
+  {
+    question: "What if it doesn't work out, or you're too slow?",
+    answer:
+      "The first reviewed PR lands within 48 hours of repo access. If it doesn't, the sprint is 25% off, automatically. That's deliberately the moment your risk is highest, so the guarantee sits right there. Beyond that, scope is fixed on day 0, so there's no runaway bill.",
+  },
+  {
+    question: "Can you just work as a normal contractor by the day?",
+    answer:
+      "That's available as a retainer, but it's not the recommended way in. The sprint sells you a reviewed outcome for a price you agree up front, which is a better deal for you than buying time and hoping. Start with a Pilot Sprint if you want to test the working relationship at low risk.",
+  },
+];
+
+export const ServicesFaq = () => {
+  return (
+    <section className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-balance">
+          Straight answers to the questions I actually get
+        </h2>
+        <div className="flex flex-col gap-4 mt-10">
+          {faqItems.map((item) => (
+            <div
+              key={item.question}
+              className="rounded-xl border border-white/10 bg-black-200/30 p-6"
+            >
+              <h3 className="text-base font-semibold text-white mb-2">
+                {item.question}
+              </h3>
+              <p className="text-sm text-white-200 leading-relaxed">
+                {item.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/services/ServicesFinalCta.tsx
+++ b/components/services/ServicesFinalCta.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import MagicButton from "@/components/ui/MagicButton";
+import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 
 export const ServicesFinalCta = () => {
@@ -23,7 +24,7 @@ export const ServicesFinalCta = () => {
             title="Book a scoping call"
             icon={<FaLocationArrow />}
             position="right"
-            href="/#contact"
+            href={CALENDLY_URL}
           />
         </div>
         <Link

--- a/components/services/ServicesFinalCta.tsx
+++ b/components/services/ServicesFinalCta.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import MagicButton from "@/components/ui/MagicButton";
+import { FaLocationArrow } from "react-icons/fa6";
+
+export const ServicesFinalCta = () => {
+  return (
+    <section className="px-5 sm:px-10 py-20">
+      <div className="max-w-5xl mx-auto rounded-2xl border border-white/10 bg-black-200/60 p-10 md:p-16 text-center">
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-balance max-w-3xl mx-auto">
+          Tell me the backlog. I&apos;ll tell you the number.
+        </h2>
+        <p className="text-white-200 mt-4 max-w-2xl mx-auto">
+          A 20-minute call to shape the scope and fix the price. No obligation,
+          and no &quot;100x&quot; — just the honest version of what an agent
+          fleet plus a senior reviewer can ship for you.
+        </p>
+        <p className="font-mono text-sm text-purple mt-6">
+          30 reviewed PRs in 2.5 days. 3 shell-injection bugs caught that the
+          tests passed. That&apos;s the job.
+        </p>
+        <div className="flex justify-center mt-8">
+          <MagicButton
+            title="Book a scoping call"
+            icon={<FaLocationArrow />}
+            position="right"
+            href="/#contact"
+          />
+        </div>
+        <Link
+          href="/#work"
+          className="inline-block text-sm font-medium text-blue-100 hover:text-purple transition-colors mt-6"
+        >
+          See the 30-PR sprint in full →
+        </Link>
+      </div>
+    </section>
+  );
+};

--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -1,4 +1,5 @@
 import MagicButton from "@/components/ui/MagicButton";
+import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 
 const proofItems = [
@@ -30,7 +31,7 @@ export const ServicesHero = () => {
             title="Book a scoping call"
             icon={<FaLocationArrow />}
             position="right"
-            href="/#contact"
+            href={CALENDLY_URL}
           />
           <a
             href="#process"

--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -38,6 +38,10 @@ export const ServicesHero = () => {
           >
             Not ready to talk? See exactly how the pipeline works ↓
           </a>
+          <p className="text-xs text-white-200/70 mt-1">
+            First reviewed PR within 48 hours of repo access — or the sprint is
+            25% off.
+          </p>
         </div>
 
         <div className="flex flex-wrap justify-center items-center gap-x-3 gap-y-2 mt-10 max-w-3xl mx-auto">

--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -1,0 +1,61 @@
+import MagicButton from "@/components/ui/MagicButton";
+import { FaLocationArrow } from "react-icons/fa6";
+
+const proofItems = [
+  "30 reviewed PRs · 9 agent batches · 2.5 days",
+  "3 shell-injection vulnerabilities caught that passed the tests",
+  "10+ years in production",
+];
+
+export const ServicesHero = () => {
+  return (
+    <section className="px-5 sm:px-10 pt-28 sm:pt-32 pb-16">
+      <div className="max-w-5xl mx-auto text-center">
+        <h1 className="text-3xl md:text-5xl font-bold tracking-tight text-balance max-w-3xl mx-auto">
+          Reviewed outcomes at agent speed — priced before we start
+        </h1>
+        <p className="text-white-200 mt-5 leading-relaxed max-w-2xl mx-auto">
+          This is fixed-scope, fixed-price delivery, not a timesheet. You agree
+          the batch of pull requests and the number up front. An agent fleet
+          writes the volume; I adversarially review every PR for security before
+          it reaches you. Nothing reaches you that a senior engineer hasn&apos;t
+          personally checked.
+        </p>
+        <p className="inline-block text-center font-mono text-xs md:text-sm text-purple mt-5 border-l-2 border-purple pl-3">
+          2-3x, not 100x — and here&apos;s what the agents get wrong.
+        </p>
+
+        <div className="flex flex-col items-center gap-4 mt-6">
+          <MagicButton
+            title="Book a scoping call"
+            icon={<FaLocationArrow />}
+            position="right"
+            href="/#contact"
+          />
+          <a
+            href="#process"
+            className="text-sm font-medium text-blue-100 hover:text-purple transition-colors"
+          >
+            Not ready to talk? See exactly how the pipeline works ↓
+          </a>
+        </div>
+
+        <div className="flex flex-wrap justify-center items-center gap-x-3 gap-y-2 mt-10 max-w-3xl mx-auto">
+          {proofItems.map((item, index) => (
+            <span
+              key={item}
+              className="flex items-center gap-3 font-mono text-[11px] md:text-xs text-white-200/80"
+            >
+              {index !== 0 && (
+                <span className="text-white-200/40" aria-hidden="true">
+                  ·
+                </span>
+              )}
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/services/TrustStrip.tsx
+++ b/components/services/TrustStrip.tsx
@@ -1,0 +1,49 @@
+const employers = ["Ipsos", "PGL Esports", "GoSocial", "Bono Fintech"];
+
+export const TrustStrip = () => {
+  return (
+    <section
+      aria-label="Track record and testimonial"
+      className="px-5 sm:px-10 py-16"
+    >
+      <div className="max-w-5xl mx-auto">
+        <p className="text-center font-mono text-[11px] uppercase tracking-[0.12em] text-white-200/60">
+          10+ years shipping production software
+        </p>
+        <div className="flex flex-wrap justify-center items-center gap-x-6 gap-y-3 mt-5">
+          {employers.map((name, index) => (
+            <span key={name} className="flex items-center gap-6">
+              {index !== 0 && (
+                <span className="text-white-200/30" aria-hidden="true">
+                  ·
+                </span>
+              )}
+              <span className="text-sm font-semibold text-white-200/80">
+                {name}
+              </span>
+            </span>
+          ))}
+        </div>
+
+        <figure className="mt-12 max-w-3xl mx-auto rounded-2xl border border-white/10 bg-black-200/40 p-8 md:p-10">
+          <blockquote className="text-base md:text-lg leading-relaxed text-white-200">
+            &ldquo;I am very pleased with Adrian&apos;s efforts and progress on
+            my project. I was informed on a daily basis about progress, and
+            Adrian is very keen on delivering quality work. He made sure I was
+            happy with the end result. I definitely recommend contacting Adrian
+            if you are in need of any web related projects.&rdquo;
+          </blockquote>
+          <figcaption className="mt-6 flex items-center gap-3">
+            <span className="text-sm font-semibold text-white">Tim Claes</span>
+            <span className="text-white-200/40" aria-hidden="true">
+              ·
+            </span>
+            <span className="text-sm text-white-200/70">
+              Freelance mobile &amp; web engineer
+            </span>
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+  );
+};

--- a/components/ui/MagicButton.tsx
+++ b/components/ui/MagicButton.tsx
@@ -35,9 +35,17 @@ const MagicButton = ({
   // When an href is given, render a single anchor (via Radix Slot) so we never
   // nest a <button> inside an <a> — that is invalid HTML and trips hydration.
   if (href) {
+    const isExternal = href.startsWith("http");
     return (
       <Button asChild className={magicClasses}>
-        <Link href={href}>{inner}</Link>
+        <Link
+          href={href}
+          {...(isExternal
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {})}
+        >
+          {inner}
+        </Link>
       </Button>
     );
   }

--- a/components/ui/MagicButton.tsx
+++ b/components/ui/MagicButton.tsx
@@ -1,18 +1,52 @@
-import { Button } from "./button"
+import Link from "next/link";
+import { Button } from "./button";
+
+const magicClasses =
+  "relative w-full inline-flex h-12 overflow-hidden rounded-lg p-[1px] focus:outline-none md:w-60 md:mt-10";
 
 const MagicButton = ({
-  title, icon, position, handleClick, otherClasses
-}: { title: string, icon: React.ReactNode, position: string, handleClick?: () => void, otherClasses?: string }) => {
-  return (
-    <Button className="relative w-full inline-flex h-12 overflow-hidden rounded-lg p-[1px] focus:outline-none md:w-60 md:mt-10" onClick={handleClick}>
+  title,
+  icon,
+  position,
+  handleClick,
+  otherClasses,
+  href,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  position: string;
+  handleClick?: () => void;
+  otherClasses?: string;
+  href?: string;
+}) => {
+  const inner = (
+    <>
       <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
-      <span className={`inline-flex h-full w-full cursor-pointer items-center justify-center rounded-lg bg-slate-950 px-7 text-sm font-medium text-white backdrop-blur-3xl gap-2 ${otherClasses}`} >
-        {position === 'left' && icon}
+      <span
+        className={`inline-flex h-full w-full cursor-pointer items-center justify-center rounded-lg bg-slate-950 px-7 text-sm font-medium text-white backdrop-blur-3xl gap-2 ${otherClasses}`}
+      >
+        {position === "left" && icon}
         {title}
-        {position === 'right' && icon}
+        {position === "right" && icon}
       </span>
-    </Button >
-  )
-}
+    </>
+  );
 
-export default MagicButton
+  // When an href is given, render a single anchor (via Radix Slot) so we never
+  // nest a <button> inside an <a> — that is invalid HTML and trips hydration.
+  if (href) {
+    return (
+      <Button asChild className={magicClasses}>
+        <Link href={href}>{inner}</Link>
+      </Button>
+    );
+  }
+
+  return (
+    <Button className={magicClasses} onClick={handleClick}>
+      {inner}
+    </Button>
+  );
+};
+
+export default MagicButton;

--- a/data/index.ts
+++ b/data/index.ts
@@ -1,3 +1,5 @@
+export const CALENDLY_URL = "https://calendly.com/adrian-rusan";
+
 export const navItems = [
   { name: "How it works", link: "#ship-verify" },
   { name: "Services", link: "#offers" },

--- a/notes/pricing-ship-verify-2026-07-09.md
+++ b/notes/pricing-ship-verify-2026-07-09.md
@@ -1,0 +1,132 @@
+# Ship / Verify — Pricing Strategy (2026-07-09)
+
+Research-backed pricing for the productized services on adrian-rusan.com/services.
+Produced by a 6-agent workflow: 4 market-research lenses → synthesis → adversarial sanity-check (verdict: ADJUST, 5 corrections applied). Approved for publishing 2026-07-09.
+
+## Final published prices (LIVE on /services)
+
+### Delivery Sprint
+| Tier | Published | Scope | Internal ceiling (quote toward on the call) |
+|---|---|---|---|
+| Pilot | **from €7,500** | 5–6 reviewed PRs · ~3–5 days | €9,500 |
+| **Standard** *(recommended)* | **from €14,500** | 10–15 PRs · ~1–2 weeks | €18,000 |
+| Scale | **from €24,000 — scoped after a 30-min assessment** | 16–20+ PRs · ~2–3 weeks | €30,000 |
+
+### Retainer (monthly)
+| Tier | Published | Scope |
+|---|---|---|
+| Steady | **from €7,000/mo** | 6–8 reviewed PRs/mo, 3-mo min |
+| **Core** *(recommended)* | **from €12,000/mo** | 12–15 PRs/mo, priority queue |
+| Embedded | **from €22,000/mo — 1 slot** | 20+ PRs/mo, dedicated capacity (quote toward €25–27k as proof accumulates) |
+
+### Harness Setup
+| Tier | Published | Scope |
+|---|---|---|
+| Install | **from €9,000** | one repo · ~1 wk |
+| **Install + Enablement** *(recommended)* | **from €18,000** | + workshops · ~2 wks |
+| Fleet Rollout | **from €30,000 — scoped after assessment** | multi-repo / org-wide |
+
+## The one idea
+
+Price against the **buyer's alternative**, not the operator's Romanian cost base. A Western senior-contractor-month is €12–16k for **1×** output. Ship/Verify delivers **2–3× + bundled adversarial security review**, and the verify layer is **supply-capped at ~2 concurrent slots**. Supply-constrained ⇒ optimize **value-per-slot**, not conversion volume. A too-low published number is worse than a lost tire-kicker: it anchors the whole relationship and burns a scarce, non-parallelizable slot. (The original draft Pilot at €4,000 was ~2× too low.)
+
+## Anchoring strategy
+
+Three tiers everywhere (3-tier pages convert ~1.4× two-tier; 4+ convert worse). Asymmetric-dominance decoy on Sprint: **Pilot is small and priced HIGHER per-PR than Standard** — its job is to push buyers up, not to be the value play. **Standard is the per-PR-cheapest hero** ("a senior contractor-month of reviewed output"), engineered to catch the 60–70% who pick the middle. **Scale is the high visible anchor** that makes Standard feel modest. Published "from" anchors filter; the internal ceiling captures on the call based on repo familiarity, security surface, and timeline pressure. Scale/Embedded/Fleet use "from + scoped after assessment" — custom scope + on-brand for anti-hype work + the assessment call is itself a qualification step.
+
+## Two value ceilings to sell against
+
+1. **Hire-replacement (sell Standard + Core against this):** fully-loaded Western-EU senior = €110–150k/yr (~€9–12.5k/mo) + recruiter fee (15–25% of first-year = €13.5–37.5k) + 1–3 mo ramp, and every unfilled seat bleeds **€10–20k/mo in lost output already being paid**. Rational ceiling ≈ **€20–30k/mo** — which is why a €14.5–18k Standard reads as a discount.
+2. **Breach/insurance (sell the VERIFY layer against this):** IBM 2025 avg financial-services breach ≈ **€5.1M** (+22% vs global), unsupervised/shadow-AI adds ~€620k, slow detection adds ~€1.02M. One prevented shell-injection vuln (3 caught that passed tests) is worth a large multiple of any sprint fee. The security review is bundled into every PR — never a cuttable line item.
+
+## Adversarial adjustments applied (from the sanity-check)
+
+- Standard €13,500 → **€14,500** (supply-constrained; anchor was at contractor-month floor).
+- Embedded €20,000 → **€22,000/mo** (scarcest asset was at its own floor).
+- Steady €6,500 → **€7,000/mo** (was the cheapest reviewed-PR unit in the system — anomaly).
+- Pilot scope 5–8 → **5–6 PRs** (holds €7,500; makes per-PR strictly > Standard in ALL scenarios so the decoy is robust to range cherry-picking).
+- Scale + Embedded + Fleet → **"from + scoped/1-slot"** presentation, not clean published numbers.
+
+## Risks & when to revisit
+
+**Likely too LOW:** (1) US-heavy inbound → shift **+20–40%** (US Standard could carry €18–22k). (2) Security premium may be under-captured (packaged secure-code-review floor ~€27k, pentests reach €45k) → Scale/Embedded could carry +20–30%. (3) Genuine scarcity → if the calendar fills, **RAISE anchors, don't queue**.
+**Possibly too HIGH:** (4) If ICP skews earlier-stage/less-funded, the hire-replacement ceiling weakens — watch **Pilot→Standard conversion**; if Pilots don't convert, the decoy is mispriced, not Standard. (5) Single reference proof (3 vulns, one 30-PR run) → **quote toward internal ceilings only once 2–3 named case studies exist.**
+**What changes them:** signed named-fintech case study → **+20% across the board**; a second verify operator (removes 2-slot bottleneck) → LOWER per-unit to chase volume; majority-US pipeline → reprice in USD at the higher band. **Revisit every 2–3 closed deals.**
+
+---
+
+## Market research (4 lenses)
+
+### Lens: contractor-rates
+
+A "senior contractor-month" is the single most useful anchor for the Standard sprint tier, and its cost depends entirely on which market's rate you quote. Western-European senior full-stack contractors bill roughly €80-100/hr at the top and commonly €500-800/day remote (a German-facing senior remote day rate benchmark sits around €632), which annualizes to a senior contractor-month of ~€12,000-16,000 at ~20 billed days. Eastern-Europe/Romania senior contractors sit 35-40% below that — roughly $45-70/hr (€42-65) or €360-560/day, i.e. a senior contractor-month of ~€8,000-11,000; Romania's oft-cited ~€16/hr average blends in all juniors and is NOT the senior remote-to-West rate. The EE-vs-WE gap is explicit in the data: WE $70-130/hr vs EE $30-70/hr. Fractional/retainer models cluster higher per month because they bundle judgment and accountability, not hours: fractional-CTO retainers run $2,999-15,000/mo (core band ~$8-15k ≈ €7,500-13,500), and fractional senior-engineer retainers run $5-10k/mo (≈€4,600-9,300). US senior contractors ($80-180/hr, fractional leads $200-350/hr) sit clearly above EU and support a US-facing premium. Strategic read: because Adrian sells reviewed OUTCOMES to EU/US funded startups, he should anchor the Standard tier to the buyer's own senior-contractor-month cost (~€12-15k Western/blended), not his Romanian cost base — the 2-3x throughput plus adversarial security review is the justification to price at or above one Western senior-contractor-month, while his EE cost base (~€8-11k) is pure margin, not a price ceiling.
+
+**Anchors:**
+- Western-EU senior full-stack contractor day rate: €500-800/day (€80-100/hr top end)
+- Western-EU senior contractor-MONTH (~20 days): ~€12,000-16,000 — the anchor for the 'recommended' Standard tier
+- Eastern-EU/Romania senior contractor day rate: €360-560/day ($45-70/hr)
+- Eastern-EU senior contractor-month: ~€8,000-11,000 (Adrian's cost base, not a price ceiling)
+- EE-vs-WE differential: EE 35-40% cheaper; WE $70-130/hr vs EE $30-70/hr
+- Fractional-CTO monthly retainer: $2,999-15,000/mo, core band $8-15k (≈€7,500-13,500)
+- Fractional senior-engineer retainer: $5,000-10,000/mo (≈€4,600-9,300)
+- US senior contractor: $80-180/hr (7+yr >$100/hr); US fractional leads $200-350/hr — supports US-facing premium
+- Romania all-levels average ~€16/hr — a blended junior-inclusive figure, NOT the senior remote-to-West rate
+
+**Sources:** https://www.index.dev/blog/european-developer-hourly-rates, https://brainsource.io/european-remote-developer-rates-2025/, https://www.remotepass.com/blog/global-contractor-rates-2025, https://devico.io/blog/cost-of-hiring-romanian-developers-in-2025-rate-guide, https://lemon.io/rate-calculator/romania/, https://wild.codes/blog/cost-of-hiring-eastern-european-developers-in-2025, https://fractionalctoexperts.com/blog/fractional-cto-pricing-guide, https://truvisory.com/fractional-cto/fractional-cto-cost/, https://www.fractionaljobs.io/help/how-much-does-fractional-talent-cost-to-hire, https://www.fullstack.com/labs/resources/blog/software-development-price-guide-hourly-rate-comparison, https://arc.dev/freelance-developer-rates/full-stack, https://www.quora.com/What-is-the-average-daily-remote-contract-rate-for-a-senior-software-engineer-in-Europe
+
+### Lens: ai-agentic-dev-services
+
+The 2025-2026 market splits into three reference bands that bracket these offers. (1) Fixed-price AI-native "build" engagements cluster at $15k-$40k (~€14k-€37k) for a production workflow shipped in 6-12 weeks, often phased as Discovery ~$5k (~€4.6k) + Build $18k-$25k (~€17k-€23k) + optional Run retainer $2k-$6k/mo (~€1.8k-€5.5k). (2) Productized week-long sprints (design/dev sprint model, e.g. thoughtbot, Zypsy) sit at $8k-$25k (~€7.5k-€23k) per single-focus sprint with a senior practitioner, and $25k-$30k for a full 5-day sprint with prototype + IP transfer. (3) Underlying labor floor: senior Western-EU full-stack/architect contractors bill €80-100/hr, i.e. roughly €640-800/day, so a "senior contractor-month of reviewed output" anchors around €13k-€16k — a clean justification for the Standard sprint tier. Monthly dev retainers broadly run €3k-€10k (with €5k-€8k/mo buying ~30-50 hrs of steady feature delivery), while AI-automation agency retainers tier from ~€1.5k-€4k (base) through ~€4k-€12k (full-service) and $2k-$20k+ at the mid/upper end. Fixed-price scoped audits/prototypes land at $12k-$40k (~€11k-€37k) and full production systems with QA/monitoring/handover at $50k-$100k (~€46k-€92k). Notably, "governed/reviewed AI output" (versioned prompts, audit logs, reviewer queues, human-in-the-loop) is emerging explicitly as a premium differentiator that supports pricing above the commodity T&M band of $80-250/hr — directly validating the adversarial-security-review positioning. Hourly billing is in visible decline across AI-focused services in favor of outcome/output pricing, so fixed-scope PR-count packaging is on-trend rather than novel.
+
+**Anchors:**
+- Fixed-price AI-native build engagement: ~€14k-€37k for a production workflow shipped in 6-12 weeks (maps to Sprint Standard/Scale)
+- Phased AI-native model: Discovery ~€4.6k + Build ~€17k-€23k + Run retainer ~€1.8k-€5.5k/mo (validates Pilot -> Standard -> Retainer ladder)
+- Productized single-focus week sprint (senior practitioner): ~€7.5k-€23k; full 5-day design sprint with IP transfer ~€23k-€28k
+- Senior Western-EU full-stack/architect contractor: €80-100/hr => ~€640-800/day => ~€13k-€16k for a 'contractor-month' (anchor for Standard sprint 'senior contractor-month of reviewed output')
+- Monthly software dev retainer: ~€3k-€10k/mo; €5k-€8k/mo buys ~30-50 hrs steady feature delivery (floor for Retainer Steady/Core tiers)
+- AI-automation agency retainer tiers: base ~€1.5k-€4k, mid avg ~€3k, full-service ~€4k-€12k/mo (Embedded tier can push €12k-€20k+)
+- Fixed-price scoped audit/prototype: ~€11k-€37k; full production system with QA/monitoring/handover: ~€46k-€92k (upper bound / Scale reference)
+- Commodity AI-dev T&M band being displaced: $80-250/hr (~€75-230/hr) — the floor the reviewed-outcomes framing must price above
+- Single-agent AI MVP build (agency): $50k-$70k (~€46k-€64k); dedicated team $15k-€60k/mo — context for harness-setup + enablement upsell
+
+**Sources:** https://ai-native-agency.com/, https://thoughtbot.com/services/product-design-sprint, https://design-sprint.com/prices/, https://llms.zypsy.com/design-sprint-agency, https://www.index.dev/blog/european-developer-hourly-rates, https://brainsource.io/european-remote-developer-rates-2025/, https://www.kumohq.co/blog/software-development-retainer-vs-fixed-price-agency-2026, https://taskip.net/ai-automation-agency-pricing/, https://digitalagencynetwork.com/ai-agency-pricing/, https://www.techaheadcorp.com/blog/agentic-ai-development-costs/, https://productcrafters.io/blog/how-much-does-it-cost-to-build-an-ai-agent/, https://www.launchadvisor.co/guides/value-based-pricing-custom-software-development-company, https://shipkit.us/blog/fixed-price-mvp-development-how-to-launch-your-product-predictably-in-2026, https://getdx.com/blog/ai-coding-assistant-pricing/
+
+### Lens: security-review-premium
+
+The "VERIFY" half — senior manual/adversarial security review — commands roughly 2-3x a plain senior delivery day rate, and that multiple is the core of Adrian's pricing power. Senior security consultants bill $1,000-$3,500+/day (~EUR 900-3,200/day); pentesters quote $1,000-$3,000/day (~EUR 900-2,700), versus a senior EU full-stack contractor at ~EUR 450-700/day. The premium is corroborated structurally: security specialists earn a documented 40-60% pay premium over general developers (Index.dev/RemotePass 2025), and hourly appsec consultants run $200-$350/hr (~EUR 180-320). Packaged secure-code-review engagements have a high floor — professional-services firms cite "no less than $30,000" (~EUR 27k), while scoped small-app reviews start ~$8,000 (~EUR 7k) and complex apps run $10,000-$18,000 (~EUR 9-16k), typically 1-3 weeks of a single expert's time (Schellman, ScienceSoft, Software Secured). Web-app pentests, the closest one-shot adversarial analog, land at $5,000-$30,000 (~EUR 4.5-27k), up to $50k for complex scope. On the recurring side, PTaaS subscriptions anchor at ~$2,500/month platform fee plus ~$1,800 per 8-hour credit, with annual contract values of $15,000-$50,000 (~EUR 13.5-45k) — a useful ceiling reference for the AI-Native Delivery Retainer. Two tailwinds support premium positioning: security-review rates rose 15-20% since 2024 on demand/talent shortage, and the human verify layer is explicitly non-parallelizable, which is exactly the scarcity that justifies day rates at the top of these bands rather than the middle. Adrian's differentiator (adversarial security review bundled into every delivered PR, with proof like 3 caught shell-injection vulns) lets him charge the security-review premium on top of delivery, not as a separate line item buyers can cut.
+
+**Anchors:**
+- Senior security consultant day rate: ~EUR 900-3,200/day ($1,000-$3,500+); general cyber consultant avg ~EUR 780/day ($865)
+- Pentester/adversarial-review day rate: ~EUR 900-2,700/day ($1,000-$3,000)
+- Senior EU full-stack contractor (plain delivery) baseline: ~EUR 450-700/day — the number the security layer is 2-3x above
+- Security-specialist pay premium over general devs: +40-60% (documented market delta)
+- Appsec consultant hourly: ~EUR 180-320/hr ($200-$350); London EUR 225-540, Berlin EUR 135-315
+- Packaged secure code review, professional-services floor: ~EUR 27k+ ($30,000 minimum cited)
+- Secure code review, scoped small app: ~EUR 7k ($8,000); complex app: ~EUR 9-16k ($10,000-$18,000), 1-3 weeks single expert
+- Web-app pentest (one-shot adversarial): ~EUR 4.5-27k ($5,000-$30,000), up to ~EUR 45k for complex
+- PTaaS recurring: ~EUR 2,250/mo platform ($2,500) + ~EUR 1,600 per 8h credit ($1,800); ACV ~EUR 13.5-45k ($15,000-$50,000)
+- Market movement: security-review rates up 15-20% since 2024 on demand + talent shortage
+
+**Sources:** https://www.blazeinfosec.com/post/how-much-does-penetration-testing-cost/, https://www.getastra.com/blog/security-audit/penetration-testing-cost/, https://deepstrike.io/blog/penetration-testing-cost, https://www.schellman.com/services/penetration-testing/secure-code-review, https://www.softwaresecured.com/post/the-best-secure-code-review-providers-in-2026, https://www.scnsoft.com/security/pricing, https://iso27001cost.com/consultant-cost, https://www.contractrates.fyi/CyberSecurity-Consultant/hourly-rates, https://www.cleveroad.com/blog/it-consulting-rates/, https://www.index.dev/blog/freelance-developer-rates-by-country, https://www.remotepass.com/blog/global-contractor-rates-2025, https://www.brightdefense.com/resources/penetration-testing-pricing/, https://vulnvoyager.com/blog/ptaas-penetration-testing-as-a-service-market-pricing/, https://firecompass.com/ptaas-pricing-2026-models-what-you-get/
+
+### Lens: value-anchoring-wtp
+
+For this ICP (funded, fintech-adjacent eng leaders), the rational value ceiling is set by two independent anchors, and the offer should sit far below one and be justified by the other. Anchor 1 — replacement cost of a senior hire: a Western-EU senior engineer runs €110k-150k/yr fully loaded (a €90k German senior = ~€110-115k loaded), i.e. ~€9-12.5k/month, PLUS a one-time recruiter fee of 15-25% of first-year salary (€13.5-37.5k) and 1-3 months of ramp at reduced productivity, on a 4-10 week time-to-hire that stretches with 1-3 month notice periods. Critically, every unfilled senior seat bleeds €10-20k/month in lost output — that vacancy cost is the real WTP driver, because the buyer is already paying it while unable to hire. Stacking loaded salary-equivalent (~€9-12.5k) + vacancy/opportunity cost (~€10-20k) means a "senior-contractor-month of reviewed output" can rationally be anchored at €20-30k/month before any risk premium, so a €12-18k Standard sprint reads as a bargain. Anchor 2 — the breach/insurance ceiling justifies premium pricing on the security-review layer: IBM's 2025 report puts the average financial-services breach at $5.56M (~€5.1M, 22% above the $4.44M global average), with shadow/unsupervised AI adding ~$670k and slow detection (>200 days) adding ~$1.02M; a single prevented shell-injection vuln reaching prod is worth a large multiple of any sprint fee, which is exactly the fear these buyers pay to retire. On conversion structure: three-tier pages convert ~1.4x two-tier (and 4+ tiers convert worse), 60-70% of consulting buyers pick the middle tier, and a well-built "anchor–hero–decoy" spread lifts premium/mid selection 30-40% (Ariely), so the recommended architecture is exactly three tiers with Standard as the margin-rich hero, Pilot as the entry/decoy, and Scale as the high visible anchor.
+
+**Anchors:**
+- Fully-loaded EU senior engineer: €110k-150k/yr (~€9-12.5k/month) — the salary-replacement floor the Standard sprint maps to
+- Recruiter fee: 15-25% of first-year salary = €13.5k-37.5k one-time, before any ramp or productivity loss
+- Vacancy cost: €10-20k/month in lost output per unfilled senior seat — the buyer is already paying this; it is the core WTP driver
+- Derived rational ceiling for a 'senior-contractor-month of reviewed output': ~€20-30k/month (loaded salary + vacancy cost), so a €12-18k Standard tier reads as a discount
+- Fintech/financial-services data breach: $5.56M avg (~€5.1M), 22% above the $4.44M global average — the catastrophe-avoidance ceiling that justifies a premium on the adversarial security review
+- Unsupervised/shadow-AI breach premium: +$670k (~€620k); slow detection (>200 days): +$1.02M — direct dollar value of the human verify layer
+- Recommended 3-tier spread ~1 : 2 : 3 mirroring PR counts — e.g. Pilot ~€6-8k (decoy/entry), Standard ~€12-18k (hero, where 60-70% land), Scale ~€22-30k (high anchor)
+- CEE senior contractor reference: €40-70/hr (~€7-12k/month) — the low commodity comparison to price ABOVE, not toward, given the reviewed-outcome + accountability premium
+
+**Sources:** https://www.highcircl.com/en/blog/cost-to-hire-senior-developer-europe, https://decode.agency/article/hidden-costs-hiring-in-house-developers/, https://www.index.dev/blog/european-developer-hourly-rates, https://www.ibm.com/reports/data-breach, https://opti9tech.com/blog/the-real-cost-of-a-data-breach-for-financial-services-firms/, https://www.kiteworks.com/cybersecurity-risk-management/ibm-2025-data-breach-report-ai-risks/, https://www.getmonetizely.com/articles/the-decoy-effect-how-strategic-pricing-tiers-can-maximize-revenue, https://www.digitalapplied.com/blog/subscription-pricing-page-psychology-decision-framework-2026, https://www.agent37.com/blog/pricing-strategy-for-consulting-services, https://untappedpricing.co.uk/the-anchoring-effect-in-pricing/
+
+
+
+---
+
+*Full raw workflow output (all sources, anchors, per-lens detail) archived in the session task log; regenerate via the pricing-research workflow script if needed.*


### PR DESCRIPTION
## What

Builds the **/services** route — the productized-offer / how-it-works page — from the marketing draft (`page-services.md`). This is the conversion page the homepage `Services` nav and offer cards point toward.

## Sections (8, in order)

1. **Hero** — H1, honest 2-3x proof line, `Book a scoping call` CTA, proof strip.
2. **How the work runs** — the ship/verify 4-step process (`#process`).
3. **Primary offer: Agent-Accelerated Delivery Sprint** — deliverables, 3-tier pricing table (Standard highlighted), what-it-is-NOT, two concrete guarantees, payment.
4. **Retainer** + **5. Harness Setup** — secondary offers.
6. **Honest scarcity** — the verify layer doesn't parallelize.
7. **FAQ** — 6 objection-handling Q&A (all the draft contains).
8. **Final CTA band**.

## Notable

- **FloatingNav** added with home-relative items so the standalone route is navigable; **canonical** metadata set.
- **MagicButton** gains an optional `href` that renders a *single* anchor via Radix Slot — fixes the `<button>`-inside-`<a>` invalid-HTML/hydration pattern for these CTAs. Backward-compatible; the no-href path is unchanged.
- CTAs → `/#contact`, case-study link → `/#work` (the dedicated `/contact` and `/work` routes don't exist yet).
- Numbers held to canon: 2-3x, 10+ years, 30 PRs / 9 batches / 2.5 days, 3 shell-injection vulns.

## How it was built

Multi-agent workflow: 1 implementer build → 3-lens adversarial verify (correctness+build, brand-copy, links/a11y/SEO). 0 blockers; the MEDIUM/LOW findings were applied (MagicButton nesting, scarcity lead-in, canonical, nav) or intentionally kept (anchor links, 6 FAQ). Verified in-browser end-to-end — no console/hydration warnings.

## ⚠️ NEEDS FROM ADI before this is truly live

- **Confirm the published Pilot price** — draft ships `from €4,000`. Everything else reads *"Quoted after scope call."*
- **Retainer concurrent cap** — copy currently says *"only a couple run alongside the sprints"* rather than a hard number.
- **Booking link** — CTAs point at the homepage `#contact` mailto; a real scheduling URL would replace it.

## Verification

- `tsc --noEmit`: no new errors. `eslint` on new files: clean.
- Pre-existing `next build` /500 prerender failure (Sentry `<Html>` in `global-error`) is unrelated to this PR — no `/services` entry in the build error output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)