### PR TITLE
Pricing & offer restructure: one flagship, €1k entry offer, quality-trigger reversal

### DIFF
--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -3,6 +3,7 @@ import { FloatingNav } from "@/components/ui/FloatingNav";
 import { ServicesHero } from "@/components/services/ServicesHero";
 import { ProcessSteps } from "@/components/services/ProcessSteps";
 import { DeliverySprint } from "@/components/services/DeliverySprint";
+import { EntryOffer } from "@/components/services/EntryOffer";
 import { TrustStrip } from "@/components/services/TrustStrip";
 import { Retainer } from "@/components/services/Retainer";
 import { HarnessSetup } from "@/components/services/HarnessSetup";
@@ -52,12 +53,12 @@ const servicesFaqStructuredData = [
   {
     question: "What if it doesn't work out, or you're too slow?",
     answer:
-      "The first reviewed PR lands within 48 hours of repo access. If it doesn't, the sprint is 25% off, automatically. That's deliberately the moment your risk is highest, so the guarantee sits right there. Beyond that, scope is fixed on day 0, so there's no runaway bill.",
+      "If the first reviewed PR isn't merge-ready to your standard, you don't pay for it — your risk is highest before I've shipped anything, so the guarantee sits right there. Beyond that, scope is fixed on day 0, so there's no runaway bill.",
   },
   {
     question: "Can you just work as a normal contractor by the day?",
     answer:
-      "That's available as a retainer, but it's not the recommended way in. The sprint sells you a reviewed outcome for a price you agree up front, which is a better deal for you than buying time and hoping. Start with a Pilot Sprint if you want to test the working relationship at low risk.",
+      "That's available as a retainer, starting at €9,000/mo, but it's not the recommended way in. The sprint sells you a reviewed outcome for a price you agree up front, which is a better deal for you than buying time and hoping. The retainer carries the same security guarantee, plus a proof-month: month 1 is a trial, and you can cancel at the end of it if we haven't hit the agreed reviewed-PR cadence. Start with a Pilot Sprint if you want to test the working relationship at low risk first.",
   },
 ];
 
@@ -99,6 +100,7 @@ export default function ServicesPage() {
       <ServicesHero />
       <ProcessSteps />
       <DeliverySprint />
+      <EntryOffer />
       <TrustStrip />
       <Retainer />
       <HarnessSetup />

--- a/components/Offers.tsx
+++ b/components/Offers.tsx
@@ -13,26 +13,51 @@ const Offers = () => {
           start.
         </p>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mt-12">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5 mt-12 items-start">
           {offers.map((offer) => (
             <div
               key={offer.id}
-              className={`relative flex flex-col rounded-xl p-6 bg-black-200/40 border ${offer.featured ? "border-purple shadow-[inset_0_0_0_1px_#CBACF9]" : "border-white/10"}`}
+              className={
+                offer.featured
+                  ? "relative flex flex-col rounded-xl p-6 bg-black-200/40 border border-purple shadow-[inset_0_0_0_1px_#CBACF9] md:scale-[1.03] md:py-8"
+                  : "relative flex flex-col rounded-xl p-5 bg-black-200/20 border border-white/10 opacity-80"
+              }
             >
               {offer.badge && (
                 <span className="font-mono text-[10px] font-bold uppercase tracking-[0.1em] text-purple mb-3">
                   {offer.badge}
                 </span>
               )}
-              <h3 className="text-lg font-semibold mb-3 tracking-tight">
+              <h3
+                className={
+                  offer.featured
+                    ? "text-lg font-semibold mb-3 tracking-tight"
+                    : "text-base font-semibold mb-2 tracking-tight text-white-200"
+                }
+              >
                 {offer.title}
               </h3>
-              <p className="text-sm text-white-200 leading-relaxed flex-1">
+              <p
+                className={
+                  offer.featured
+                    ? "text-sm text-white-200 leading-relaxed flex-1"
+                    : "text-sm text-white-200/80 leading-relaxed flex-1"
+                }
+              >
                 {offer.body}
               </p>
+              {offer.featured && (
+                <p className="text-xs text-white-200/70 mt-4">
+                  Sprints from €7,500 — most €12–18k, fixed on the call.
+                </p>
+              )}
               <a
                 href="/services"
-                className="text-sm font-medium text-purple hover:underline underline-offset-4 mt-5"
+                className={
+                  offer.featured
+                    ? "text-sm font-medium text-purple hover:underline underline-offset-4 mt-5"
+                    : "text-sm font-medium text-purple/80 hover:underline underline-offset-4 mt-4"
+                }
               >
                 Learn more →
               </a>

--- a/components/services/DeliverySprint.tsx
+++ b/components/services/DeliverySprint.tsx
@@ -14,11 +14,11 @@ const deliverables = [
     rest: "what the agent produced, what the review caught and changed, and the residual risk, if any.",
   },
   {
-    lead: "A security findings log for the whole sprint",
+    lead: "The Sprint Security Report (yours to keep)",
     rest: "— every vulnerability class checked, everything caught and fixed, stated plainly. This is the artifact the sprint is selling.",
   },
   {
-    lead: "A sprint wrap doc:",
+    lead: "The Agent Failure Map (yours to keep) —",
     rest: "what shipped, what's left, and what the agents consistently got wrong in your codebase — a useful map for your team going forward.",
   },
 ];
@@ -49,9 +49,9 @@ const rows: PricingRow[] = [
   {
     label: "Roughly",
     values: [
-      "~5–6 reviewed PRs",
-      "~10–15 reviewed PRs",
-      "~16–20+ reviewed PRs",
+      "A focused feature slice (~5–6 PRs)",
+      "A reviewed contractor-month (~10–15 PRs)",
+      "A major surface, in depth (~16–20+ PRs)",
     ],
   },
   {
@@ -104,6 +104,14 @@ export const DeliverySprint = () => {
           </ul>
 
           <h3 className="text-lg font-semibold mt-10 mb-4">Pricing</h3>
+          <p className="text-white-200 mb-6 leading-relaxed max-w-3xl text-base md:text-lg">
+            <span className="text-white font-semibold">
+              A senior contractor costs ~€10–14k/month and takes weeks to
+              onboard.
+            </span>{" "}
+            Standard ships a reviewed contractor-month — in two weeks. €14,500,
+            fixed.
+          </p>
           <PricingTable
             columns={columns}
             rows={rows}
@@ -151,13 +159,12 @@ export const DeliverySprint = () => {
             </div>
             <div className="rounded-xl border border-white/10 bg-black-200/30 p-5">
               <p className="font-mono text-xs text-purple mb-2">
-                2. First-PR proof guarantee
+                2. First-PR quality guarantee
               </p>
               <p className="text-sm text-white-200 leading-relaxed">
-                The first reviewed PR lands within 48 hours of repo access. If
-                it doesn&apos;t, that sprint is 25% off — no argument. Your risk
-                is highest before I&apos;ve shipped anything, so the guarantee
-                sits right there.
+                If the first reviewed PR isn&apos;t merge-ready to your
+                standard, you don&apos;t pay for it. Your risk is highest before
+                I&apos;ve shipped anything, so the guarantee sits right there.
               </p>
             </div>
           </div>
@@ -165,7 +172,7 @@ export const DeliverySprint = () => {
             There is deliberately no blanket &quot;money back if unhappy&quot;
             guarantee. It invites scope disputes and it&apos;s not how a senior
             operator works. These two put my skin in the game where it actually
-            matters: speed and security.
+            matters: quality and security.
           </p>
 
           <h3 className="text-lg font-semibold mt-10 mb-2">Payment</h3>

--- a/components/services/EntryOffer.tsx
+++ b/components/services/EntryOffer.tsx
@@ -1,0 +1,61 @@
+import MagicButton from "@/components/ui/MagicButton";
+import { CALENDLY_URL } from "@/data";
+import { FaLocationArrow } from "react-icons/fa6";
+
+const steps = [
+  "You send one real ticket from your backlog — a bug, a small feature, whatever's actually queued.",
+  "An agent ships it. I security-review the diff line by line, the same adversarial pass every sprint PR gets.",
+  "You get the merge-ready PR, on your repo, plus a one-page review report showing exactly what the review caught.",
+  "Delivered in ~48 hours.",
+];
+
+export const EntryOffer = () => {
+  return (
+    <section id="entry-offer" className="px-5 sm:px-10 py-20">
+      <div className="max-w-6xl mx-auto rounded-2xl border border-white/10 bg-black-200/40 p-6 md:p-10">
+        <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-blue-100">
+          Not ready for a full sprint?
+        </span>
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight mt-3 text-balance">
+          The Reviewed PR — €1,000
+        </h2>
+        <p className="text-white-200 mt-5 leading-relaxed max-w-3xl">
+          The lowest-risk way to see the method work on your own code, before
+          you commit to a sprint.
+        </p>
+
+        <ul className="flex flex-col gap-3 mt-8">
+          {steps.map((item) => (
+            <li
+              key={item}
+              className="flex gap-3 text-sm text-white-200 leading-relaxed"
+            >
+              <span className="text-purple flex-none">+</span>
+              {item}
+            </li>
+          ))}
+        </ul>
+
+        <div className="rounded-xl border border-purple bg-black-200/60 p-5 md:p-6 mt-8 max-w-2xl">
+          <p className="text-sm text-white font-medium leading-relaxed">
+            Fully credited toward any Delivery Sprint you book within 30 days.
+          </p>
+          <p className="text-sm text-white-200/80 mt-2 leading-relaxed">
+            If you move to a Pilot, Standard, or Scale Sprint within a month,
+            the €1,000 comes straight off the price — this is a free look at the
+            work, not a separate purchase.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-4 mt-8">
+          <MagicButton
+            title="Start with one PR"
+            icon={<FaLocationArrow />}
+            position="right"
+            href={CALENDLY_URL}
+          />
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/services/HarnessSetup.tsx
+++ b/components/services/HarnessSetup.tsx
@@ -1,8 +1,6 @@
 import MagicButton from "@/components/ui/MagicButton";
 import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
-import { PricingTable } from "./PricingTable";
-import type { PricingColumn, PricingRow } from "./PricingTable";
 
 const deliverables = [
   "A working Claude Code agent harness configured against your repo: CLAUDE.md project rules, the worktree and dispatch workflow, and CI wiring.",
@@ -17,27 +15,6 @@ const terms = [
   "Requires your team present and participating — this is assistive by design, not done-for-you. Said plainly so expectations match.",
   "Doesn't include Claude Code licenses or third-party tool seats — you bring your own accounts.",
   "The harness is configured and handed over; I don't retain access unless you add a retainer.",
-];
-
-const columns: PricingColumn[] = [
-  { name: "Install" },
-  { name: "Install + Enablement", badge: "Recommended", featured: true },
-  { name: "Fleet Rollout" },
-];
-
-const rows: PricingRow[] = [
-  {
-    label: "Scope",
-    values: [
-      "One repo: agent fleet config, CI security gates, review rubric + runbook. ~1 week.",
-      "Everything in Install, plus 2–3 workshops, tuned review rubrics, methodology transfer, 30 days support. ~2 weeks.",
-      "Multi-repo / org-wide standards, embedded pairing, security-gate policy across services, advisory handoff.",
-    ],
-  },
-  {
-    label: "Price",
-    values: ["€9,000", "€18,000", "€30,000 — fixed on the scope call"],
-  },
 ];
 
 export const HarnessSetup = () => {
@@ -72,12 +49,28 @@ export const HarnessSetup = () => {
         </ul>
 
         <h3 className="text-lg font-semibold mt-10 mb-4">Pricing</h3>
-        <PricingTable
-          columns={columns}
-          rows={rows}
-          ctaHref={CALENDLY_URL}
-          ctaLabel="Book a scoping call"
-        />
+        <div className="rounded-xl border border-white/10 bg-black-200/60 p-6 md:p-8 max-w-2xl">
+          <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-blue-100">
+            Harness setup
+          </span>
+          <p className="text-3xl md:text-4xl font-bold tracking-tight mt-2">
+            Starts at €9,000
+          </p>
+          <p className="text-sm text-white-200/80 mt-3 leading-relaxed">
+            One repo: agent fleet config, CI security gates, review rubric,
+            handover playbook, and follow-up support. Scope grows with
+            multi-repo rollout, extra workshops, and embedded pairing — scoped
+            and fixed on the call, before any work starts.
+          </p>
+          <div className="mt-6">
+            <MagicButton
+              title="Book a scoping call"
+              icon={<FaLocationArrow />}
+              position="right"
+              href={CALENDLY_URL}
+            />
+          </div>
+        </div>
         <p className="text-xs text-white-200/70 mt-4 italic">
           Locked on day 0, no runaway bill — the price is fixed on the scope
           call, before any work starts.

--- a/components/services/Retainer.tsx
+++ b/components/services/Retainer.tsx
@@ -1,8 +1,7 @@
+import Link from "next/link";
 import MagicButton from "@/components/ui/MagicButton";
 import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
-import { PricingTable } from "./PricingTable";
-import type { PricingColumn, PricingRow } from "./PricingTable";
 
 const deliverables = [
   "A committed monthly PR throughput band, all adversarially reviewed — the same ship/verify pipeline as the sprint, on a continuous cadence.",
@@ -12,30 +11,9 @@ const deliverables = [
 ];
 
 const terms = [
-  "Throughput is a band, not unlimited. Overflow rolls to the next month or a top-up sprint.",
+  "Throughput is a band, not unlimited. Overflow rolls to the next month or a top-up sprint. The exact band is scoped on the call.",
   "Not 24/7 on-call incident response — that can be added as a named line item, priced separately.",
   "Month-to-month after an initial 3-month commitment. Cancel anytime after that with 30 days' notice. Long enough to prove it works, short enough to be honest. No lock-in beyond the proof period.",
-];
-
-const columns: PricingColumn[] = [
-  { name: "Steady" },
-  { name: "Core", badge: "Recommended", featured: true },
-  { name: "Embedded" },
-];
-
-const rows: PricingRow[] = [
-  {
-    label: "Roughly",
-    values: [
-      "~6–8 reviewed PRs/mo",
-      "~12–15 reviewed PRs/mo",
-      "~20+ reviewed PRs/mo, dedicated",
-    ],
-  },
-  {
-    label: "Price",
-    values: ["€7,000/mo", "€12,000/mo", "€22,000/mo — 1 slot"],
-  },
 ];
 
 export const Retainer = () => {
@@ -70,16 +48,69 @@ export const Retainer = () => {
         </ul>
 
         <h3 className="text-lg font-semibold mt-10 mb-4">Pricing</h3>
-        <PricingTable
-          columns={columns}
-          rows={rows}
-          ctaHref={CALENDLY_URL}
-          ctaLabel="Book a scoping call"
-        />
+        <div className="rounded-xl border border-white/10 bg-black-200/30 p-6 md:p-8">
+          <p className="font-mono text-xs uppercase tracking-[0.1em] text-blue-100 mb-2">
+            Starts at
+          </p>
+          <p className="text-3xl md:text-4xl font-bold text-white">
+            €9,000
+            <span className="text-base font-normal text-white-200">/mo</span>
+          </p>
+          <p className="text-sm text-white-200 mt-4 leading-relaxed max-w-2xl">
+            A permanently reserved senior-review slot and a committed monthly
+            band of reviewed PRs, on the same ship/verify pipeline as the
+            sprint. The exact band and per-PR rate are scoped on the call,
+            against your repo and cadence — a 3-month initial commitment.
+          </p>
+          <p className="text-sm text-white-200/80 mt-3 leading-relaxed max-w-2xl">
+            The per-PR rate lands roughly 20–30% below the one-off Sprint rate —
+            that&apos;s what the monthly commitment buys you. No published rate
+            card; specifics are scoped on the call.
+          </p>
+          <div className="mt-6">
+            <Link
+              href={CALENDLY_URL}
+              aria-label="Book a scoping call"
+              {...(CALENDLY_URL.startsWith("http")
+                ? { target: "_blank", rel: "noopener noreferrer" }
+                : {})}
+            >
+              <span className="inline-flex items-center rounded-lg border border-purple/40 px-4 py-2 text-xs font-medium text-purple hover:bg-purple/10 transition-colors">
+                Book a scoping call
+              </span>
+            </Link>
+          </div>
+        </div>
         <p className="text-xs text-white-200/70 mt-4 italic">
           Your monthly band is locked on day 0, no runaway bill — overflow rolls
           forward instead of surprise invoicing.
         </p>
+
+        <h3 className="text-lg font-semibold mt-10 mb-4">The guarantees</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div className="rounded-xl border border-white/10 bg-black-200/30 p-5">
+            <p className="font-mono text-xs text-purple mb-2">
+              1. Security guarantee
+            </p>
+            <p className="text-sm text-white-200 leading-relaxed">
+              Every delivered PR passes a documented adversarial security review
+              before you see it. If a vulnerability that was in scope of that
+              review is later found in a PR I marked reviewed, I fix it free and
+              re-review the surrounding batch at no charge.
+            </p>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-black-200/30 p-5">
+            <p className="font-mono text-xs text-purple mb-2">
+              2. Proof-month guarantee
+            </p>
+            <p className="text-sm text-white-200 leading-relaxed">
+              Month 1 is the trial: we agree the reviewed-PR cadence up front,
+              and if it isn&apos;t hit, you cancel at the end of month 1 with no
+              further commitment. You confirm the retainer is working before
+              you&apos;re locked into the full 3 months.
+            </p>
+          </div>
+        </div>
 
         <h3 className="text-lg font-semibold mt-10 mb-4">Terms</h3>
         <ul className="flex flex-col gap-3">

--- a/components/services/ServicesFaq.tsx
+++ b/components/services/ServicesFaq.tsx
@@ -28,12 +28,12 @@ const faqItems: FaqItem[] = [
   {
     question: "What if it doesn't work out, or you're too slow?",
     answer:
-      "The first reviewed PR lands within 48 hours of repo access. If it doesn't, the sprint is 25% off, automatically. That's deliberately the moment your risk is highest, so the guarantee sits right there. Beyond that, scope is fixed on day 0, so there's no runaway bill.",
+      "If the first reviewed PR isn't merge-ready to your standard, you don't pay for it — your risk is highest before I've shipped anything, so the guarantee sits right there. Beyond that, scope is fixed on day 0, so there's no runaway bill.",
   },
   {
     question: "Can you just work as a normal contractor by the day?",
     answer:
-      "That's available as a retainer, but it's not the recommended way in. The sprint sells you a reviewed outcome for a price you agree up front, which is a better deal for you than buying time and hoping. Start with a Pilot Sprint if you want to test the working relationship at low risk.",
+      "That's available as a retainer, starting at €9,000/mo, but it's not the recommended way in. The sprint sells you a reviewed outcome for a price you agree up front, which is a better deal for you than buying time and hoping. The retainer carries the same security guarantee, plus a proof-month: month 1 is a trial, and you can cancel at the end of it if we haven't hit the agreed reviewed-PR cadence. Start with a Pilot Sprint if you want to test the working relationship at low risk first.",
   },
 ];
 

--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -26,6 +26,10 @@ export const ServicesHero = () => {
         <p className="inline-block text-center font-mono text-xs md:text-sm text-purple mt-5 border-l-2 border-purple pl-3">
           2-3x, not 100x — and here&apos;s what the agents get wrong.
         </p>
+        <p className="font-mono text-xs md:text-sm text-white-200/60 mt-3">
+          Delivery Sprints start at €7,500 — most land €12–18k, fixed on the
+          scope call.
+        </p>
 
         <div className="flex flex-col items-center gap-4 mt-6">
           <MagicButton

--- a/notes/pricing-offer-proposal-2026-07-09.md
+++ b/notes/pricing-offer-proposal-2026-07-09.md
@@ -1,0 +1,97 @@
+# Pricing & Offer Restructure — Proposal (Group A)
+
+**Date**: 2026-07-09 · **For sign-off before implementation** · Addresses audit findings pricing-1/2/3/6/7/8 + offer-1/2/3/4/5/6.
+
+This is one coherent redesign of the `/services` money section and the homepage Offers block. Pricing is fully open — this proposes the optimal architecture for the ICP (startup founders & CTOs buying reviewed agent-speed delivery). One recommended design, with the decision forks called out at the end.
+
+---
+
+## The problems today
+
+1. **Nine priced SKUs** shown before the call (Sprint 3 + Retainer 3 + Harness 3) — choice overload for a consultative sale, and it fights the page's own "I'll tell you the number on the call" close.
+2. **Value metric is "reviewed PRs"** — a unit of *effort*, not *outcome*. It hands the buyer a per-PR rate (~€1,160–1,360/PR) and invites "we only got 10 PRs, we overpaid" disputes. A PR is non-comparable across teams.
+3. **Anchor collision at ~€7k**: Pilot Sprint €7,500 (one-off), Steady Retainer €7,000/mo (recurring), Harness Install €9,000 (setup) — three different commitments reading as the same number.
+4. **Retainer prices *cheaper* per-PR** than the one-off Sprint (€890 vs €1,160) with no framing — a sharp CTO notices the flagship gets undercut.
+5. **No entry offer** — the ladder starts at €7,500, too big a first commitment for a cold founder buying an unproven "agent" service.
+6. **Weak risk reversal** — "first PR in 48h or 25% off" rewards *speed* (a vanity metric), not the *quality* the buyer is actually anxious about.
+7. **Strongest anchor buried** — the "senior contractor-month of output, reviewed, in two weeks" equivalence sits in a table cell.
+
+---
+
+## Recommended architecture
+
+**Principle: one flagship, one anchor, priced on the outcome.** Collapse to a single visible Sprint ladder; demote Retainer + Harness to one "starts at" line each; add a paid entry rung; reframe the value metric and the guarantee.
+
+### Tier 0 — NEW entry offer: "The Reviewed PR" (de-risks the cold buyer) — offer-1
+- **What**: You send one real ticket from your backlog. An agent ships it; I security-review it line-by-line; you get the merge-ready PR + a one-page review report showing exactly what the review caught.
+- **Price**: **€1,000 flat**, delivered in ~48h.
+- **The hook**: **fully credited toward any Sprint booked within 30 days.** So it's a risk-free trial of the entire method — on *your* codebase, not a case study.
+- **Why it works**: turns "trust an unproven agent service with €7.5k" into "spend €1k to watch it work on my code." It's also the honest proof the site otherwise lacks.
+
+### Tier 1 — The flagship: Delivery Sprint (the ONLY visible 3-tier ladder)
+Priced on the **outcome + the artifacts**, PR range demoted to a scoping detail (pricing-1). Numbers kept (they were research-backed), "from" already dropped.
+
+| Rung | Price | The outcome (what's sold) | ~scope (small print) |
+|---|---|---|---|
+| **Pilot** | **€7,500** | A focused feature slice, shipped and reviewed end-to-end | ~5–6 PRs · 3–5 days |
+| **Standard** ⭐ *Recommended* | **€14,500** | **A senior contractor-month of output — reviewed — in two weeks** | ~10–15 PRs · 1–2 wks |
+| **Scale** | **€24,000** | A major surface, shipped and reviewed in depth | ~16–20+ PRs · 2–3 wks |
+
+- **Anchor moves (pricing-3, offer-5)**: present **Scale first / most visibly** so it anchors; make **Standard the visually-recommended "best value"** with the contractor-month equivalence promoted to a headline line *above* the table, not a cell: *"A senior contractor costs ~€10–14k/month and takes weeks to onboard. Standard ships a reviewed contractor-month in two weeks — €14,500, fixed."*
+- Every price framed **"fixed on the scope call"**, not "from".
+
+### Tier 2 — Also available (demoted from full tables → one line each)
+This is what kills the 9-SKU overload and the €7k collision (pricing-2, pricing-3, cro-6).
+
+- **Delivery Retainer** — *"A permanently reserved senior-review slot + a committed monthly reviewed-PR band. Starts at €9,000/mo (3-month commitment). ~20–30% below one-off Sprint rate — that's what the commitment buys."* → link/expander for detail.
+  - Raising the entry from €7,000 → **€9,000/mo** clears the collision with the €7,500 Pilot and stops the retainer visually undercutting the Sprint (pricing-6). The lower per-PR rate is now *named* as a deliberate commitment discount, not an accident.
+- **Agent Harness Setup** — *"I install and harden the ship/verify harness in your repo so your team ships at agent speed with the guardrails built in. Starts at €9,000."* → link/expander.
+
+Result: **one** 3-tier ladder visible (Pilot/Standard/Scale), **two** "starts at" anchors, everything else on the call. Tier-naming inconsistency disappears because only the Sprint shows a ladder (offer-6).
+
+### Single-anchor disclosure (pricing-7, pricing-8)
+- **Services hero**: one line — *"Delivery Sprints start at €7,500 — most engagements land €12–18k, fixed on the scope call."*
+- **Homepage Offers**: lead with the Sprint as the primary card + soft anchor (*"Sprints from €7,500 — most €12–18k"*); Retainer + Harness rendered smaller/secondary.
+- Keep the detailed Sprint table for the scroller; the hero anchor and the "I'll tell you the number" close now agree (anchor sets the floor, call sets the figure).
+
+### Risk reversal — switch from speed to quality (offer-3)
+- **Primary (the Pilot/Reviewed-PR is the proof vehicle)**: *"If the first reviewed PR isn't merge-ready to your standard, you don't pay for it."* — a *quality* promise, which is what the buyer is actually anxious about.
+- **Keep the security guarantee**: *"If an in-scope vulnerability is later found in a PR I marked reviewed, I fix it free and re-review the surrounding batch."*
+- Drop the "48h or 25% off" speed trigger (or keep it as a secondary SLA, not the headline).
+- ⚠️ **Operational commitment** — only adopt "you don't pay if not merge-ready" if you're prepared to honor it. It's strong precisely because it's real.
+
+### Give the Retainer a guarantee (offer-2)
+It carries the biggest commitment (3 months × €9k+ = €27k+) yet currently has none.
+- Apply the Sprint's security guarantee verbatim.
+- **Proof-month**: month 1 is the trial — if the agreed reviewed-PR cadence isn't hit, cancel at the end of month 1, no further obligation. Softens the 3-month commit without discounting.
+
+### Name the deliverables as keepable assets (offer-4)
+The value stack is currently four flat bullets. Elevate the two that are genuinely differentiated:
+- **The Sprint Security Report** — every vulnerability class checked; what was caught and fixed; written up. *Yours to keep.*
+- **The Agent Failure Map** — what the agents consistently got wrong on *your* codebase, so your own CLAUDE.md/harness gets better. *Yours to keep.*
+
+---
+
+## What changes on the pages (implementation scope, once approved)
+
+- `components/services/DeliverySprint.tsx` — promote contractor-month anchor above table; mark Standard "Recommended"; reorder so Scale anchors; reframe rows to outcome-first.
+- `components/services/Retainer.tsx` + `HarnessSetup.tsx` — collapse from 3-tier tables to a single "starts at" card each (+ optional expander).
+- `components/services/ServicesHero.tsx` — add the single-anchor line.
+- `components/services/DeliverySprint.tsx` (guarantees) + `ServicesFaq.tsx` — swap reversal to the quality trigger; add retainer guarantee + proof-month.
+- **NEW** entry offer block (`components/services/EntryOffer.tsx`) — "The Reviewed PR" €1,000, credited.
+- `components/Offers.tsx` + `data/index.ts` (offers) — homepage leads with Sprint + soft anchor; Retainer/Harness secondary.
+- Value stack copy — name the Security Report + Failure Map.
+
+Estimated: ~M–L, one workflow, file-partitioned like the previous batches.
+
+---
+
+## Decisions — LOCKED 2026-07-09
+
+1. Sprint numbers: **keep** €7,500 / €14,500 / €24,000.
+2. Retainer entry: **raise €7,000 → €9,000/mo** (clears the collision, stops undercutting the Sprint).
+3. Entry offer: **YES — "The Reviewed PR", €1,000, credited** toward a Sprint booked within 30 days.
+4. Risk reversal: **YES — quality trigger** ("first reviewed PR not merge-ready to your standard → you don't pay for it"); keep the security guarantee. Owner has confirmed this is operationally honorable.
+5. Retainer guarantee + **proof-month**: YES (security guarantee + cancel-at-month-1 if cadence missed).
+6. Disclosure: **single anchor visible** — "Sprints start at €7,500 — most land €12–18k, fixed on the scope call."
+7. Value stack: name **The Sprint Security Report** + **The Agent Failure Map** as keepable assets.


### PR DESCRIPTION
Implements the approved Group A pricing/offer architecture (`notes/pricing-offer-proposal-2026-07-09.md`). Turns a 9-SKU menu into a single flagship ladder with a low-risk on-ramp.

## Changes
- **Collapse 9 SKUs → 1 visible ladder.** Only the Delivery Sprint shows tiers (Pilot €7,500 / Standard €14,500 ⭐ / Scale €24,000). Retainer + Harness become one "starts at" card each.
- **NEW entry offer — "The Reviewed PR", €1,000.** Send one real ticket → shipped + security-reviewed in ~48h → merge-ready PR + review report. **Credited toward any Sprint within 30 days.** The low-risk proof-on-your-own-code on-ramp.
- **Sprint**: contractor-month equivalence promoted from a table cell to a headline anchor; rows reframed outcome-first (PR counts → small print); Security Report + Agent Failure Map named as keepable assets.
- **Risk reversal → quality trigger**: "if the first reviewed PR isn't merge-ready to your standard, you don't pay for it." Replaces the 48h/25%-off speed gimmick. Synced across the Sprint guarantee, the FAQ, and the FAQPage JSON-LD.
- **Retainer**: single €9,000/mo card (up from €7k — clears the price collision + stops undercutting the Sprint) + security guarantee + proof-month (cancel after month 1 if cadence missed).
- **Single-anchor disclosure** on the services hero; homepage leads with the Sprint + soft anchor.

## Decisions (signed off)
€1k entry offer · quality-trigger reversal (owner confirmed operationally honorable) · keep Sprint numbers, raise Retainer to €9k · show single anchor. Full rationale + locked decisions in the proposal note.

## Verified
`npm run build` green (19/19) · `tsc --noEmit` clean · no unverified metrics in copy or JSON-LD.

Generated with the portfolio-groupA-pricing multi-agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)