### PR TITLE
Fix: stale reversal copy in services hero + doubled title suffix

### DIFF
--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -12,8 +12,8 @@ import { ServicesFaq } from "@/components/services/ServicesFaq";
 import { ServicesFinalCta } from "@/components/services/ServicesFinalCta";
 
 export const metadata: Metadata = {
-  title:
-    "Services — Agent-Accelerated Delivery Sprints, Reviewed | Adrian Rusan",
+  // Bare title — the root layout's title.template appends "| Adrian Rusan"
+  title: "Services — Agent-Accelerated Delivery Sprints, Reviewed",
   description:
     "Fixed-scope, fixed-price sprints: an agent fleet ships the volume, a senior engineer security-reviews every PR before you see it.",
   openGraph: {

--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -45,8 +45,8 @@ export const ServicesHero = () => {
             Not ready to talk? See exactly how the pipeline works ↓
           </a>
           <p className="text-xs text-white-200/70 mt-1">
-            First reviewed PR within 48 hours of repo access — or the sprint is
-            25% off.
+            If the first reviewed PR isn&apos;t merge-ready to your standard,
+            you don&apos;t pay for it.
           </p>
         </div>
 


### PR DESCRIPTION
Two defects caught verifying the merged Group A restructure on production:

1. **Stale risk-reversal in the services hero** — it still read "First reviewed PR within 48 hours ... or the sprint is 25% off" (the old speed trigger) while the Sprint guarantee + FAQ + FAQPage schema now use the quality trigger. The hero owns its own copy and was missed. Now: "If the first reviewed PR isn't merge-ready to your standard, you don't pay for it."
2. **Doubled title** — `/services` rendered `... Reviewed | Adrian Rusan | Adrian Rusan` because the page title carried a suffix that the root `title.template` already appends. Dropped the manual suffix from the page title (OG title keeps the full form).

Verified: `npm run build` green (19/19), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)