### PR TITLE
Honest provenance on the services-hero proof strip

### DIFF
--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -65,6 +65,11 @@ export const ServicesHero = () => {
             </span>
           ))}
         </div>
+        <p className="text-[11px] md:text-xs text-white-200/50 mt-3 max-w-2xl mx-auto">
+          From a build I ran end-to-end on my own repo — the PRs, the review
+          notes, and the findings are real, and I&apos;ll walk you through them
+          on the call.
+        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
Last live trust exposure on the money page: the `/services` hero proof strip asserted "30 reviewed PRs · 9 agent batches · 2.5 days · 3 shell-injection vulnerabilities caught" as bare fact, with no provenance — a CTO who clicks through the linked blog learns it was a self-run build on the author's own repo.

Adds the same honest-provenance caption ProofBand and CaseStudy already carry: "From a build I ran end-to-end on my own repo — the PRs, the review notes, and the findings are real, and I'll walk you through them on the call." Numbers are kept (real for that build); only the framing is made honest.

Verified: `npm run build` green (19/19), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)