### PR TITLE
✨ /teardown — free async top-of-funnel offer + intake

### DIFF
--- a/__tests__/api-teardown.test.ts
+++ b/__tests__/api-teardown.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from "@/app/api/teardown/route";
+
+// Outside production the route no-ops (returns ok:true without any network
+// call) when the ESP env vars are unset — so these guard tests exercise the
+// input-validation path in isolation. In production that same unset-env path
+// fails closed (Sentry alert + 500); covered by the separate describe below.
+beforeEach(() => {
+  delete process.env.RESEND_API_KEY;
+  delete process.env.EMAIL_FROM;
+});
+
+function post(body: string) {
+  return POST(
+    new Request("http://localhost/api/teardown", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    }),
+  );
+}
+
+const VALID_REPO = "https://github.com/you/your-repo/pull/42";
+
+describe("POST /api/teardown — input guard", () => {
+  it("rejects a non-JSON body with 400", async () => {
+    const res = await post("not-json");
+    expect(res.status).toBe(400);
+    expect((await res.json()).ok).toBe(false);
+  });
+
+  it("rejects a malformed email with 400", async () => {
+    const res = await post(
+      JSON.stringify({ email: "nope", repoUrl: VALID_REPO }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing or non-http repo URL with 400", async () => {
+    for (const bad of [
+      undefined,
+      "",
+      "not a url",
+      "ftp://x.com",
+      "javascript:alert(1)",
+    ]) {
+      const res = await post(
+        JSON.stringify({ email: "founder@startup.io", repoUrl: bad }),
+      );
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("accepts a valid request and no-ops when no ESP is configured", async () => {
+    const res = await post(
+      JSON.stringify({ email: "Founder@Startup.io", repoUrl: VALID_REPO }),
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+});
+
+describe("POST /api/teardown — production misconfig fails closed", () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  // @types/node types NODE_ENV as read-only; assign through the index signature.
+  const setNodeEnv = (value: string | undefined) => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = value;
+  };
+
+  afterEach(() => {
+    setNodeEnv(ORIGINAL_NODE_ENV);
+    jest.dontMock("@sentry/nextjs");
+    jest.resetModules();
+  });
+
+  it("alerts Sentry once and returns 500 (never a fake ok:true) when the ESP env is unset in prod", async () => {
+    const captureMessage = jest.fn();
+    jest.resetModules();
+    jest.doMock("@sentry/nextjs", () => ({
+      captureMessage,
+      captureException: jest.fn(),
+    }));
+    setNodeEnv("production");
+    delete process.env.RESEND_API_KEY;
+    delete process.env.EMAIL_FROM;
+
+    const { POST: ProdPOST } = await import("@/app/api/teardown/route");
+    const res = await ProdPOST(
+      new Request("http://localhost/api/teardown", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "founder@startup.io",
+          repoUrl: VALID_REPO,
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).ok).toBe(false);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("teardown request dropped"),
+      "error",
+    );
+  });
+});

--- a/app/api/teardown/route.ts
+++ b/app/api/teardown/route.ts
@@ -1,0 +1,197 @@
+import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+
+// Free-teardown intake → Resend. On submit we notify Adrian of the request,
+// send the submitter a confirmation, and (best-effort) add them to the nurture
+// audience. No SDK — Resend's REST API over fetch keeps the surface small.
+//
+// Required env (unset = safe dev no-op; in PRODUCTION unset fails closed so a
+// misconfiguration can't silently drop lead requests behind a fake success):
+//   RESEND_API_KEY       server-side API key (never exposed to the client)
+//   EMAIL_FROM           verified sender, e.g. "Adrian Rusan <hello@adrian-rusan.com>"
+// Optional:
+//   TEARDOWN_NOTIFY_TO   where the request notification lands (default contact@)
+//   RESEND_AUDIENCE_ID   audience the submitter is added to (best-effort nurture only)
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const NOTIFY_TO = process.env.TEARDOWN_NOTIFY_TO ?? "contact@adrian-rusan.com";
+const MAX_NOTE = 2000;
+
+// User-supplied values are embedded in an HTML email body — escape to prevent
+// HTML/attribute injection in whatever mail client renders the notification.
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+// Fire the prod-misconfig alert at most once per warm instance so a flood
+// against this unauthenticated endpoint during a misconfig window can't burn
+// Sentry quota or bury the signal. The 500 still fires on every request.
+let misconfigAlerted = false;
+
+const isHttpUrl = (value: string) => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid request body." },
+      { status: 400 },
+    );
+  }
+
+  const field = (key: string): unknown =>
+    typeof body === "object" && body !== null && key in body
+      ? (body as Record<string, unknown>)[key]
+      : undefined;
+
+  const email = field("email");
+  const repoUrl = field("repoUrl");
+  const note = field("note");
+
+  if (typeof email !== "string" || !EMAIL_PATTERN.test(email.trim())) {
+    return NextResponse.json(
+      { ok: false, error: "Please provide a valid email address." },
+      { status: 400 },
+    );
+  }
+
+  if (typeof repoUrl !== "string" || !isHttpUrl(repoUrl.trim())) {
+    return NextResponse.json(
+      { ok: false, error: "Please provide a valid repo or PR URL." },
+      { status: 400 },
+    );
+  }
+
+  const sanitizedEmail = email.trim().toLowerCase();
+  const sanitizedRepo = repoUrl.trim();
+  const sanitizedNote =
+    typeof note === "string" ? note.trim().slice(0, MAX_NOTE) : "";
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.EMAIL_FROM;
+
+  if (!apiKey || !from) {
+    if (process.env.NODE_ENV === "production") {
+      // Misconfiguration in prod is a silent black-hole: the visitor sees
+      // success but no request is delivered. Alert loudly (once per warm
+      // instance) and fail closed rather than faking a 200.
+      if (!misconfigAlerted) {
+        Sentry.captureMessage(
+          "[teardown] RESEND_API_KEY/EMAIL_FROM unset in production — teardown request dropped",
+          "error",
+        );
+        misconfigAlerted = true;
+      }
+      return NextResponse.json(
+        { ok: false, error: "Something went wrong. Please try again." },
+        { status: 500 },
+      );
+    }
+    // Dev/staging without Resend configured — no-op success so the UI works.
+    console.warn(
+      "[teardown] RESEND_API_KEY/EMAIL_FROM not set. Skipping request for:",
+      sanitizedEmail,
+    );
+    return NextResponse.json({ ok: true });
+  }
+
+  const authHeaders = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+
+  const audienceId = process.env.RESEND_AUDIENCE_ID;
+
+  // 1. Add to the audience (best-effort — nurture, not the primary value).
+  if (audienceId) {
+    try {
+      const res = await fetch(
+        `https://api.resend.com/audiences/${audienceId}/contacts`,
+        {
+          method: "POST",
+          headers: authHeaders,
+          body: JSON.stringify({ email: sanitizedEmail, unsubscribed: false }),
+        },
+      );
+      if (!res.ok && res.status !== 409) {
+        console.warn("[teardown] Resend audience add returned:", res.status);
+      }
+    } catch (error) {
+      console.warn("[teardown] Resend audience add failed:", error);
+    }
+  }
+
+  // 2. Notify Adrian — this is the primary value (a lead asked for a teardown).
+  //    If this send fails, fail the request so the submitter retries rather
+  //    than believing a request was delivered that never arrived.
+  try {
+    const noteBlock = sanitizedNote
+      ? `<p><strong>Note:</strong> ${escapeHtml(sanitizedNote)}</p>`
+      : "";
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({
+        from,
+        to: NOTIFY_TO,
+        reply_to: sanitizedEmail,
+        subject: "New teardown request",
+        html: `
+          <p>New free-teardown request:</p>
+          <p><strong>From:</strong> ${escapeHtml(sanitizedEmail)}</p>
+          <p><strong>Repo/PR:</strong> <a href="${escapeHtml(sanitizedRepo)}">${escapeHtml(sanitizedRepo)}</a></p>
+          ${noteBlock}
+        `,
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Resend notify responded with ${res.status}`);
+    }
+  } catch (error) {
+    console.error("[teardown] Failed to send request notification:", error);
+    Sentry.captureException(error);
+    return NextResponse.json(
+      { ok: false, error: "Something went wrong. Please try again." },
+      { status: 502 },
+    );
+  }
+
+  // 3. Confirm to the submitter (best-effort — the request is already logged
+  //    with Adrian, so a failed confirmation shouldn't fail the whole request).
+  try {
+    await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({
+        from,
+        to: sanitizedEmail,
+        subject: "Your code teardown is on the way",
+        html: `
+          <p>Thanks — I've got your teardown request.</p>
+          <p>I'll review the repo or PR you sent and record a ~15-minute Loom of what your AI-generated code is hiding — security bugs that pass tests and merge anyway. You'll have it within 2&ndash;3 business days, no call required.</p>
+          <p>If anything's unclear about the repo, I'll reply to this email.</p>
+          <p>— Adrian</p>
+        `,
+      }),
+    });
+  } catch (error) {
+    console.warn("[teardown] Confirmation email failed (non-fatal):", error);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -27,6 +27,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/teardown`,
+      lastModified: lastModified,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/blog`,
       lastModified,
       changeFrequency: "weekly",

--- a/app/teardown/page.tsx
+++ b/app/teardown/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import dynamic from "next/dynamic";
+import { FloatingNav } from "@/components/ui/FloatingNav";
+import MagicButton from "@/components/ui/MagicButton";
+import TeardownForm from "@/components/TeardownForm";
+import { CALENDLY_URL } from "@/data";
+import { FaLocationArrow } from "react-icons/fa6";
+
+const Footer = dynamic(() => import("@/components/Footer"), {
+  loading: () => (
+    <footer
+      className="h-32 animate-pulse bg-slate-100 dark:bg-slate-800"
+      aria-label="Footer loading"
+    />
+  ),
+});
+
+const TITLE =
+  "Free AI Code Teardown — a 15-min Loom of what your AI-generated code is hiding";
+const DESCRIPTION =
+  "Send a repo or a recent PR. I'll send back a free 15-minute Loom teardown of the security bugs your AI coding tools wrote that pass tests and merge anyway. No call, no pitch.";
+
+export const metadata: Metadata = {
+  title: "Free AI Code Teardown — 15-min Loom, no call",
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    type: "website",
+  },
+  alternates: {
+    canonical: "/teardown",
+  },
+};
+
+const teardownNavItems = [
+  { name: "Home", link: "/" },
+  { name: "Services", link: "/services" },
+  { name: "Work", link: "/#work" },
+  { name: "Blog", link: "/blog" },
+];
+
+const steps = [
+  "Paste a repo or PR link below — something real you've shipped with Copilot, Cursor, or Claude Code.",
+  "I run the same adversarial security review every sprint PR gets — injection, auth, secrets, access control — assuming the agent got it wrong until it's proven right.",
+  "You get a ~15-minute Loom walking through exactly what I found, usually within 2–3 business days. Free.",
+];
+
+export default function TeardownPage() {
+  return (
+    <main className="relative dark:bg-black-100 bg-white overflow-hidden">
+      <FloatingNav navItems={teardownNavItems} />
+
+      <section className="px-5 sm:px-10 pt-28 sm:pt-32 pb-16">
+        <div className="max-w-5xl mx-auto text-center">
+          <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-blue-100">
+            Free · async · no call
+          </span>
+          <h1 className="text-3xl md:text-5xl font-bold tracking-tight text-balance max-w-3xl mx-auto mt-4">
+            Send me a repo. I&apos;ll show you what your AI-generated code is
+            hiding.
+          </h1>
+          <p className="text-white-200 mt-5 leading-relaxed max-w-2xl mx-auto">
+            A free, 15-minute Loom teardown of a repo or a recent PR — the
+            security bugs that pass your tests and merge anyway. I&apos;ve
+            caught shell-injection vulnerabilities that every automated check
+            waved through. No call, no pitch, no signup beyond your email.
+          </p>
+        </div>
+      </section>
+
+      <section
+        className="px-5 sm:px-10 pb-16"
+        aria-label="How the teardown works"
+      >
+        <div className="max-w-3xl mx-auto">
+          <ul className="flex flex-col gap-4">
+            {steps.map((item, index) => (
+              <li
+                key={item}
+                className="flex gap-4 text-sm md:text-base text-white-200 leading-relaxed"
+              >
+                <span
+                  className="flex-none font-mono text-purple"
+                  aria-hidden="true"
+                >
+                  {index + 1}.
+                </span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="px-5 sm:px-10 pb-16" aria-label="Request a teardown">
+        <div className="max-w-2xl mx-auto">
+          <TeardownForm />
+        </div>
+      </section>
+
+      <section className="px-5 sm:px-10 pb-20" aria-label="Why free">
+        <div className="max-w-3xl mx-auto rounded-2xl border border-white/10 bg-black-200/40 p-6 md:p-8">
+          <h2 className="text-lg font-semibold tracking-tight">
+            Why is this free?
+          </h2>
+          <p className="text-sm text-white-200 mt-3 leading-relaxed">
+            Because showing you beats telling you. Most AI-code pitches claim
+            they catch bugs; this one hands you the bugs, in your own code, for
+            nothing. If it&apos;s useful, we can talk about shipping your
+            backlog this way — agent-speed delivery with every PR reviewed
+            before it reaches you. If not, you keep the teardown and we both
+            move on.
+          </p>
+
+          <div className="flex flex-col sm:flex-row sm:items-center gap-4 mt-8">
+            <MagicButton
+              title="Prefer to talk? Book a scoping call"
+              icon={<FaLocationArrow />}
+              position="right"
+              href={CALENDLY_URL}
+            />
+            <a
+              href="/services"
+              className="text-sm font-medium text-blue-100 hover:text-purple transition-colors"
+            >
+              Or see the full delivery offer →
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  );
+}

--- a/components/TeardownForm.tsx
+++ b/components/TeardownForm.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { track } from "@vercel/analytics";
+import { cn } from "@/lib/utils";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+const TeardownForm = ({ className }: { className?: string }) => {
+  const [email, setEmail] = useState("");
+  const [repoUrl, setRepoUrl] = useState("");
+  const [note, setNote] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (status === "loading") return;
+
+    setStatus("loading");
+    setErrorMessage("");
+
+    try {
+      const response = await fetch("/api/teardown", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, repoUrl, note }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Teardown request failed");
+      }
+
+      // Named conversion event — no PII in props.
+      track("teardown_request");
+      setStatus("success");
+      setEmail("");
+      setRepoUrl("");
+      setNote("");
+    } catch {
+      setStatus("error");
+      setErrorMessage("Something went wrong. Please try again in a moment.");
+    }
+  };
+
+  const inputClass =
+    "w-full h-11 rounded-lg border border-white/10 bg-black-200/60 px-4 text-sm text-white placeholder:text-white-200/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple focus-visible:border-purple disabled:opacity-50";
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-white/10 bg-black-200/40 p-6 md:p-8",
+        className,
+      )}
+    >
+      {status === "success" ? (
+        <div role="status" aria-live="polite">
+          <h3 className="text-lg font-semibold tracking-tight text-purple">
+            Got it — your teardown is on the way.
+          </h3>
+          <p className="text-sm text-white-200 leading-relaxed mt-2">
+            Check your inbox for a confirmation. You&apos;ll have the Loom
+            within 2&ndash;3 business days, no call required.
+          </p>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4"
+          noValidate
+        >
+          <div>
+            <label
+              htmlFor="teardown-repo"
+              className="block text-sm font-medium mb-2"
+            >
+              Repo or PR URL
+            </label>
+            <input
+              id="teardown-repo"
+              name="repoUrl"
+              type="url"
+              required
+              inputMode="url"
+              placeholder="https://github.com/you/your-repo/pull/42"
+              value={repoUrl}
+              onChange={(event) => setRepoUrl(event.target.value)}
+              disabled={status === "loading"}
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="teardown-email"
+              className="block text-sm font-medium mb-2"
+            >
+              Email
+            </label>
+            <input
+              id="teardown-email"
+              name="email"
+              type="email"
+              required
+              autoComplete="email"
+              placeholder="you@company.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              disabled={status === "loading"}
+              aria-describedby={
+                status === "error" ? "teardown-error" : undefined
+              }
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="teardown-note"
+              className="block text-sm font-medium mb-2"
+            >
+              Anything I should focus on?{" "}
+              <span className="text-white-200/60 font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="teardown-note"
+              name="note"
+              rows={3}
+              maxLength={2000}
+              placeholder="e.g. this PR was mostly agent-written; I'm nervous about the auth changes."
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              disabled={status === "loading"}
+              className="w-full rounded-lg border border-white/10 bg-black-200/60 px-4 py-3 text-sm text-white placeholder:text-white-200/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple focus-visible:border-purple disabled:opacity-50 resize-y"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={status === "loading"}
+            className="h-11 shrink-0 rounded-lg bg-purple px-5 text-sm font-medium text-black-100 transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple focus-visible:ring-offset-2 focus-visible:ring-offset-black-100 disabled:opacity-50"
+          >
+            {status === "loading"
+              ? "Sending…"
+              : "Send it — get my free teardown"}
+          </button>
+
+          <p className="text-xs text-white-200/60 leading-relaxed">
+            Free. No call. I&apos;ll only email you the teardown and the
+            occasional note on shipping AI-written code safely — unsubscribe
+            anytime.
+          </p>
+
+          {status === "error" && (
+            <p
+              id="teardown-error"
+              className="text-sm text-red-400"
+              role="alert"
+            >
+              {errorMessage}
+            </p>
+          )}
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default TeardownForm;


### PR DESCRIPTION
Initiative 3 (O3-1) of the lead-gen overhaul (`docs/plans/lead-gen-overhaul/plan-0.md`). The diagnosis: the site is a strong closer with no low-friction entry point — every path funnels to a 30-min call, a high-friction ask for cold traffic. This adds the async, zero-risk rung: **send a repo or PR → get a 15-min Loom teardown → no call.** It's the link every warm/cold DM (see `notes/outreach-*`) points at, and it doubles as the case-study factory that fixes the self-referential-proof problem.

## What's added
- **`app/teardown/page.tsx`** — landing: hero, 3-step how-it-works, intake form, honest "why free" framing, secondary "book a call" / "see the full offer" CTAs. Metadata + OG + canonical; added to `sitemap.ts`.
- **`components/TeardownForm.tsx`** — client form (repo URL + email + optional note). Fires a `teardown_request` Vercel Analytics event on success (**no PII in props**). Loading/success/error states, a11y labels + `role="alert"`.
- **`app/api/teardown/route.ts`** — notifies Adrian (primary value; failure → 502 so the submitter retries), confirms the submitter (best-effort), adds to the Resend nurture audience (best-effort).

## Security decisions (untrusted input lands in an email)
- **HTML-escapes** all user values (email, repoUrl, note) before embedding them in the notification email — prevents HTML/attribute injection in the mail client.
- **repoUrl validated to `http(s)` only** (rejects `javascript:`, `ftp:`, junk).
- **Fails closed in production** when `RESEND_API_KEY`/`EMAIL_FROM` unset — Sentry alert (once per warm instance) + 500, never a fake `ok:true`. Same pattern as the hardened `/api/subscribe`.
- `note` length-capped (2000); no secrets logged.

## Tests
`__tests__/api-teardown.test.ts` — input guards (bad email, non-http/`javascript:` repo URL), dev no-op success, prod fail-closed (500 + one `Sentry.captureMessage`). Suite: **20 tests pass.**

Gate: `tsc --noEmit` ✓ · lint ✓ · 20 jest tests ✓ · `npm run build` ✓ (`/teardown` static, `/api/teardown` dynamic).

## Known-deferred
- Endpoint still unauthenticated/unthrottled (shared with `/api/subscribe`) — `harden-subscribe-abuse`, plan Initiative 2 (Upstash/KV, gate G5).
- `teardown_request` uses `@vercel/analytics` `track()` directly; typed `lib/analytics.ts` (M4-1) can absorb it later. Custom events need the Vercel plan tier that supports them (gate G1).
- O3-4 (surface `/teardown` as the homepage primary CTA) is a separate task; this ships the destination.
- Owner-side: optionally set `TEARDOWN_NOTIFY_TO` (defaults to contact@); verify Resend env on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)