### PR TITLE
✨ Homepage Start band — surface /teardown as the primary CTA (O3-4)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,9 +8,8 @@ import FinalCta from "@/components/FinalCta";
 import EmailCapture from "@/components/EmailCapture";
 import Bio from "@/components/Bio";
 import { FloatingNav } from "@/components/ui/FloatingNav";
-import MagicButton from "@/components/ui/MagicButton";
-import { FaLocationArrow } from "react-icons/fa6";
-import { navItems, CALENDLY_URL } from "@/data";
+import { StartBand } from "@/components/StartBand";
+import { navItems } from "@/data";
 import dynamic from "next/dynamic";
 import {
   TestimonialSkeleton,
@@ -57,16 +56,7 @@ export default function Home() {
       </div>
       <Offers />
       <CaseStudy />
-      <section className="px-5 sm:px-10 py-10" aria-label="Book a scoping call">
-        <div className="flex justify-center">
-          <MagicButton
-            title="Book a scoping call"
-            icon={<FaLocationArrow />}
-            position="right"
-            href={CALENDLY_URL}
-          />
-        </div>
-      </section>
+      <StartBand />
       <WhoFor />
       <div className="max-w-7xl mx-auto px-5 sm:px-10">
         <section aria-label="Track record">

--- a/components/StartBand.tsx
+++ b/components/StartBand.tsx
@@ -1,0 +1,87 @@
+import MagicButton from "@/components/ui/MagicButton";
+import { CALENDLY_URL } from "@/data";
+import { FaLocationArrow } from "react-icons/fa6";
+
+// The primary conversion module: two low-commitment ways in, ordered by
+// friction. Free async teardown is the default path (converts cold traffic
+// that isn't ready for a call); the scoping call is the warm path. The €1k
+// Reviewed PR is surfaced as the middle rung for anyone between the two.
+export const StartBand = () => {
+  return (
+    <section
+      id="start"
+      aria-label="Ways to start"
+      className="px-5 sm:px-10 py-16"
+    >
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-2xl md:text-4xl font-bold tracking-tight text-balance max-w-3xl">
+          Ship the roadmap you can&apos;t hire for — reviewed before it reaches
+          you.
+        </h2>
+        <p className="text-white-200 mt-4 leading-relaxed max-w-2xl">
+          Two ways in, both without a commitment. See the work on your own code
+          first, or scope a sprint directly.
+        </p>
+
+        <div className="grid gap-5 md:grid-cols-2 mt-10">
+          {/* Primary — free async, lowest friction */}
+          <div className="rounded-2xl border border-purple bg-black-200/60 p-6 md:p-8 flex flex-col">
+            <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-blue-100">
+              Start free · no call
+            </span>
+            <h3 className="text-xl font-semibold tracking-tight mt-3">
+              Free code teardown
+            </h3>
+            <p className="text-sm text-white-200 leading-relaxed mt-3 flex-1">
+              Send a repo or a recent PR. Get a 15-minute Loom of the security
+              bugs your AI coding tools wrote that pass tests and merge anyway.
+              No pitch.
+            </p>
+            <div className="mt-6">
+              <MagicButton
+                title="Get my free teardown"
+                icon={<FaLocationArrow />}
+                position="right"
+                href="/teardown"
+              />
+            </div>
+          </div>
+
+          {/* Secondary — warm path */}
+          <div className="rounded-2xl border border-white/10 bg-black-200/40 p-6 md:p-8 flex flex-col">
+            <span className="font-mono text-[11px] uppercase tracking-[0.12em] text-white-200/70">
+              Ready to scope
+            </span>
+            <h3 className="text-xl font-semibold tracking-tight mt-3">
+              Book a scoping call
+            </h3>
+            <p className="text-sm text-white-200 leading-relaxed mt-3 flex-1">
+              Know you want your backlog shipped this way? Book 30 minutes and
+              we&apos;ll fix the scope and the price before anything starts.
+            </p>
+            <div className="mt-6">
+              <a
+                href={CALENDLY_URL}
+                className="inline-flex items-center gap-2 text-sm font-medium text-blue-100 hover:text-purple transition-colors"
+              >
+                Book a call
+                <FaLocationArrow className="text-xs" aria-hidden="true" />
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-sm text-white-200/80 mt-6 leading-relaxed">
+          Somewhere in between?{" "}
+          <a
+            href="/services#entry-offer"
+            className="text-blue-100 hover:text-purple transition-colors font-medium"
+          >
+            Start with one Reviewed PR — €1,000, ~48h, credited toward a sprint
+            →
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+};

--- a/notes/linkedin-cadence-2026-07-10.md
+++ b/notes/linkedin-cadence-2026-07-10.md
@@ -1,0 +1,35 @@
+# LinkedIn Cadence — 2026-07-10
+
+Initiative 1 (D1-3). The 5 real blog posts are gold rotting in a zero-traffic blog. Born-LinkedIn-first: post the hook + the real finding natively, link the full version on-site (the closer). 2–3×/week. Strongest hooks first — you're building an audience from cold, so open with the scroll-stoppers.
+
+Post URL base: `https://www.adrian-rusan.com/blog/<slug>?utm_source=linkedin&utm_medium=post`
+
+## Post skeleton (reuse every time)
+1. **Hook** (line 1, no preamble) — a concrete, slightly uncomfortable claim.
+2. **The real thing** — one specific finding/number/story, not a summary.
+3. **Why it matters to an eng leader** — the buyer's outcome (a security incident with their name on it, a hire they can't make).
+4. **Soft CTA** — "Full breakdown → {link}" or "Send me a repo, I'll show you yours." No hard sell.
+Native text + 1 image/carousel beats a bare link (LinkedIn suppresses outbound links — put the link in the first comment if reach drops).
+
+## 6-week schedule (2–3 posts/week)
+
+| Wk | Post | Source | slug | Hook line |
+|----|------|--------|------|-----------|
+| 1 | A | Shell-injection war story | `catching-shell-injection-agents-wrote` | "My AI agents wrote 3 shell-injection bugs. Every test passed. Here's the diff." |
+| 1 | B | 2-3x not 100x | `2-3x-not-100x` | "AI didn't make me 100x faster. The honest number is 2–3x — and I measured it." |
+| 2 | C | What agents get wrong | `what-agents-get-wrong` | "6 ways AI coding agents fail that green CI will never catch. A field taxonomy." |
+| 2 | D | 30 PRs in 2.5 days | `30-prs-in-2-5-days` | "30 reviewed PRs in 2.5 days. The bottleneck wasn't writing code — it was trusting it." |
+| 3 | E | Claude Code changed how I ship | `claude-code-changed-how-i-ship-software` | "10 years of experience matters MORE in the agent era, not less. Here's why." |
+| 3 | F | Net-new: one teardown finding | — | "I reviewed a stranger's AI-generated PR this week. What I found in 15 minutes:" (anonymized, from a real teardown) |
+| 4 | A′ | Re-angle Shell-injection | same | Lead with the *fix*: "How to catch the injection bug your test suite is blind to." |
+| 4 | G | Net-new: fail-open gates | from `what-agents-get-wrong` | "The scariest AI bug isn't wrong code — it's a security check that fails OPEN." |
+| 5 | H | Net-new: the review-is-the-product take | — | "Everyone's selling AI code generation. The money is in reviewing it. Here's the math." |
+| 5 | D′ | Re-angle 30 PRs | same | "Parallel git worktrees + one operator = a small team's throughput. The setup:" |
+| 6 | I | Net-new: a real client teardown case | — | Once a paid €1k PR / audit lands — the first real third-party proof. Highest-value post. |
+| 6 | J | Recap / offer-forward | — | "3 months of catching what agents ship. If you're merging AI code fast, send me a repo." → teardown CTA |
+
+## Notes
+- Weeks 1–3 are all-existing-content — zero new writing, just adaptation. No excuse to not start this week.
+- Net-new posts (F, G, H, I, J) are born on LinkedIn; promote the good ones to `content/blog/` afterward (reverse of the usual flow).
+- Post F/I require a delivered teardown / paid engagement — schedule them *after* the outreach in `outreach-list-2026-07-10.md` produces one.
+- Engagement > frequency: reply to every comment in the first hour. A post that starts a conversation with one eng leader beats 500 passive impressions.

--- a/notes/outreach-list-2026-07-10.md
+++ b/notes/outreach-list-2026-07-10.md
@@ -1,0 +1,45 @@
+# Outreach List & Weekly Cadence — 2026-07-10
+
+Initiative 1 (D1-1) of `docs/plans/lead-gen-overhaul/plan-0.md`. This is the traffic lever — the site is a strong closer with no visitors. The work is *sending*, not polishing.
+
+## Weekly commitment (D1-4 — the number the KPI dashboard measures)
+
+Every week, minimum:
+- **10 warm DMs / emails** (network + referrals) — snippets in `outreach-snippets-2026-07-10.md`
+- **3 LinkedIn posts** — schedule in `linkedin-cadence-2026-07-10.md`
+- **1–2 free teardowns delivered** for named warm contacts (manufactures the missing proof)
+
+Leading indicator = `calendly_click` by `utm_source` (once M4 instrumentation ships). Lagging = bookings. Rule: shift effort to whatever `utm_source` produces the most clicks per send. If a week has more commits than DMs, the sequencing has slipped.
+
+## Warm network (fill Pain + Hook, then send this week)
+
+The strongest path — a warm intro closes in days; a cold CTO takes weeks. Pick the hook per contact: **T** = free repo/PR teardown (lowest friction, default), **€1k** = Reviewed PR, **Audit** = fixed-price AI-security audit.
+
+| # | Name | Company / role | Relationship | Their likely pain (fill) | Hook | Channel | Status | Next action |
+|---|------|----------------|--------------|--------------------------|------|---------|--------|-------------|
+| 1 | Johan | Brikka | ex-colleague / delivery | _e.g. backlog, AI code piling up_ | T | DM | ☐ | send warm-intro |
+| 2 | — | Bono (fintech) | employer relationship | _security-sensitive, regulated_ | Audit | intro | ☐ | ask for the right eng-lead contact |
+| 3 | — | PGL Esports | ex-employer | _real-time, high-traffic_ | T | email | ☐ | send warm-intro |
+| 4 | — | GoSocial | ex-employer (scraping/dashboards) | _small team, backlog_ | €1k | DM | ☐ | send warm-intro |
+| 5 | — | Ipsos | ex-employer (300+ microsites) | _volume delivery_ | T | email | ☐ | send warm-intro |
+| 6 | Alex | — | personal | _knows who needs this_ | referral | DM | ☐ | send referral-ask |
+| 7 | Marin | — | personal | — | referral | DM | ☐ | send referral-ask |
+
+> Referral-ask contacts (Alex, Marin) don't need the pain filled — they're multipliers: ask them *who* in their network is drowning in AI-generated code.
+
+## Cold ICP targets (build 10–15 this week, then send week 2)
+
+ICP: funded startup/scaleup eng leaders (CTO / VP Eng / Head of Delivery) in **fintech, health, payments** — anywhere a security review is non-negotiable and they've adopted Copilot/Cursor/Claude Code in the last year. Source from LinkedIn (people who post about AI coding, shipping speed, or hiring backlogged eng roles).
+
+| # | Name | Company | Role | Signal (why them — a post, a hire, a product) | Hook | Status |
+|---|------|---------|------|-----------------------------------------------|------|--------|
+| 1 | | | | | T | ☐ |
+| 2 | | | | | T | ☐ |
+| 3 | | | | | T | ☐ |
+| … | | | | | | |
+
+Cold rule (from plan): reach out with the **free teardown**, not a call ask. Async proof converts cold traffic; "book 30 min" does not.
+
+## Notes
+- Until the `/teardown` page (O3-1) ships, deliver teardowns manually: they send a repo/PR link by email, you reply with a Loom. The page just makes it a one-click link for every DM.
+- Every teardown → ask for a one-line quote afterward (feeds T2-3/T2-4 real-testimonial slots).

--- a/notes/outreach-snippets-2026-07-10.md
+++ b/notes/outreach-snippets-2026-07-10.md
@@ -1,0 +1,31 @@
+# Outreach Snippets — 2026-07-10
+
+Initiative 1 (D1-2). Paste-ready, value-first, ≤5 sentences. Lead with the offer, not the site. Swap `{placeholders}`. Default async hook = free teardown (lowest friction).
+
+Links: teardown → deliver manually for now (they email a repo/PR link, you reply with a Loom); once `/teardown` ships, use `https://www.adrian-rusan.com/teardown`. Booking → `https://calendly.com/adrian-rusan/scoping-call`. Add `?utm_source=warm&utm_medium=dm` (or `linkedin` / `coldemail`) to any link you send so the dashboard can attribute it.
+
+---
+
+## 1. Warm intro (someone who knows you)
+
+> Hey {name} — you're shipping a lot with AI coding tools now, right? I do the part that's easy to skip: an adversarial security review of AI-generated diffs before they merge — I've caught shell-injection bugs that passed every test. Send me one real repo or PR and I'll send back a 15-min Loom of what your AI-written code is hiding, free, no call. Worth a look?
+
+## 2. Warm referral ask (a multiplier, not a prospect)
+
+> Hey {name} — quick ask. I'm doing security review of AI-generated code for eng teams shipping fast with Copilot/Cursor/Claude Code — the vulns that pass CI and merge anyway. Who in your network is drowning in AI-written code and quietly nervous about what's in it? Happy to give them a free 15-min teardown, no strings.
+
+## 3. Cold DM / email (ICP eng leader)
+
+> {name} — saw {signal: your post on shipping with Claude Code / you're hiring 3 backend roles}. Teams shipping at agent speed are merging AI-generated code faster than anyone's reviewing it; I catch the security bugs that pass tests (real example: 3 shell-injection vulns, all green CI). Send me a repo or a recent PR and I'll send back a 15-min Loom teardown of what it's hiding — free, no call. If it's useful, we talk; if not, you keep the teardown.
+
+## 4. Follow-up after delivering a teardown
+
+> {name} — teardown's above. If you want your backlog shipped this way — agent-speed, every diff reviewed before it reaches you — the lowest-risk start is one Reviewed PR: send a ticket, €1,000, ~48h, fully credited if you move to a sprint. Or a fixed-price audit of your recent PR history for AI-introduced vulns. Either interest you? Two-line quote for me first would also help — did the teardown land?
+
+---
+
+### Rules
+- One offer per message. Don't stack teardown + €1k + audit in the first touch — teardown first, upsell in follow-up (#4).
+- No "here's my site." The site closes; the message opens with value they can act on.
+- Personalize `{signal}` for cold — a generic blast reads as spam and kills deliverability.
+- Track sends in `outreach-list-2026-07-10.md`.


### PR DESCRIPTION
Initiative 3 (O3-4) of the lead-gen overhaul. Now that `/teardown` exists (PR #20), give it the front door.

## Change
Replaces the bare "Book a scoping call" button on the homepage (`app/page.tsx`, after CaseStudy) with `components/StartBand.tsx` — two low-commitment paths ordered by friction:
- **Primary (highlighted):** Free code teardown → `/teardown`. Converts cold traffic that isn't ready for a call.
- **Secondary:** Book a scoping call → Calendly. The warm path.
- **Middle rung, surfaced inline:** the €1,000 Reviewed PR → `/services#entry-offer`.

Outcome-first heading ("Ship the roadmap you can't hire for — reviewed before it reaches you") instead of the mechanism-forward CTA. Also includes the notes-only commit adding the Initiative 1 outreach/LinkedIn assets.

## Why
Every path previously funnelled to a 30-min call — a high-friction ask for a cold visitor who doesn't trust you yet. This adds the lower rungs the funnel was missing so the traffic the outreach is about to drive has somewhere low-risk to land.

Gate: `tsc --noEmit` ✓ · lint ✓ · 20 jest tests ✓ · `npm run build` ✓.

## Follow-ups (separate tasks)
- Hero H1 outcome-first rewrite (quick win) and the guarantee string (O3-5) are not in this PR.
- Thin instrumentation (M4) will let us measure `calendly_click` vs `teardown_request` from this band by source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)