### PR TITLE
✨ Outcome-first hero + shared guarantee + €1k async path

### DIFF
--- a/components/CaseStudy.tsx
+++ b/components/CaseStudy.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CALENDLY_URL } from "@/data";
+import { CALENDLY_URL, GUARANTEE } from "@/data";
 
 const CaseStudy = () => {
   return (
@@ -38,6 +38,7 @@ const CaseStudy = () => {
             Book a scoping call
           </a>
         </div>
+        <p className="text-xs text-white-200/70 mt-6">{GUARANTEE}</p>
       </div>
     </section>
   );

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,7 +4,7 @@ import MagicButton from "./ui/MagicButton";
 import { TextGenerateEffect } from "./ui/TextGenerateEffect";
 import { FaLocationArrow } from "react-icons/fa6";
 import SpotlightBackground from "./ui/SpotlightBackground";
-import { CALENDLY_URL } from "@/data";
+import { CALENDLY_URL, GUARANTEE } from "@/data";
 
 const Hero = () => {
   return (
@@ -23,7 +23,7 @@ const Hero = () => {
           <TextGenerateEffect
             id="hero-heading"
             className="text-center text-[40px] md:text-5xl lg:text-6xl"
-            words="Agent-speed delivery you can actually merge."
+            words="Ship the roadmap you can't hire for."
           />
 
           <p className="text-center tracking-wide mb-2 mt-2 text-sm md:text-lg lg:text-xl text-white-200 max-w-3xl">
@@ -50,18 +50,22 @@ const Hero = () => {
 
           <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 mt-2">
             <MagicButton
-              title="Book a scoping call"
+              title="Get a free teardown"
               icon={<FaLocationArrow />}
               position="right"
-              href={CALENDLY_URL}
+              href="/teardown"
             />
             <a
-              href="/services"
+              href={CALENDLY_URL}
               className="text-sm font-medium text-blue-100 hover:text-purple transition-colors md:mt-10"
             >
-              See how the sprint works →
+              Or book a scoping call →
             </a>
           </div>
+
+          <p className="text-center text-xs text-white-200/70 mt-5 max-w-xl">
+            {GUARANTEE}
+          </p>
         </div>
       </div>
     </section>

--- a/components/services/EntryOffer.tsx
+++ b/components/services/EntryOffer.tsx
@@ -1,5 +1,5 @@
 import MagicButton from "@/components/ui/MagicButton";
-import { CALENDLY_URL } from "@/data";
+import { CALENDLY_URL, CONTACT_EMAIL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 
 const steps = [
@@ -47,13 +47,23 @@ export const EntryOffer = () => {
           </p>
         </div>
 
-        <div className="flex flex-wrap gap-4 mt-8">
+        <div className="flex flex-wrap items-center gap-4 mt-8">
           <MagicButton
             title="Start with one PR"
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
           />
+          <a
+            href={`mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(
+              "Reviewed PR (€1,000)",
+            )}&body=${encodeURIComponent(
+              "Repo or ticket link:\n\nWhat needs shipping:\n",
+            )}`}
+            className="text-sm font-medium text-blue-100 hover:text-purple transition-colors"
+          >
+            Prefer email? Send the ticket, skip the call →
+          </a>
         </div>
       </div>
     </section>

--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -1,5 +1,5 @@
 import MagicButton from "@/components/ui/MagicButton";
-import { CALENDLY_URL } from "@/data";
+import { CALENDLY_URL, GUARANTEE } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 
 const proofItems = [
@@ -44,10 +44,7 @@ export const ServicesHero = () => {
           >
             Not ready to talk? See exactly how the pipeline works ↓
           </a>
-          <p className="text-xs text-white-200/70 mt-1">
-            If the first reviewed PR isn&apos;t merge-ready to your standard,
-            you don&apos;t pay for it.
-          </p>
+          <p className="text-xs text-white-200/70 mt-1">{GUARANTEE}</p>
         </div>
 
         <div className="flex flex-wrap justify-center items-center gap-x-3 gap-y-2 mt-10 max-w-3xl mx-auto">

--- a/data/index.ts
+++ b/data/index.ts
@@ -1,6 +1,13 @@
 // event slug must exist in Calendly ("scoping-call" 30-min event)
 export const CALENDLY_URL = "https://calendly.com/adrian-rusan/scoping-call";
 
+// Async intake inbox for offers that don't require a call.
+export const CONTACT_EMAIL = "contact@adrian-rusan.com";
+
+// Single risk-reversal guarantee, reused verbatim at every money CTA.
+export const GUARANTEE =
+  "If the first reviewed PR isn't merge-ready to your standard, you don't pay for it.";
+
 export const navItems = [
   { name: "How it works", link: "#ship-verify" },
   { name: "Services", link: "#offers" },


### PR DESCRIPTION
Quick-wins + Initiative 3 (O3-2, O3-5) of the lead-gen overhaul. Sharpens the now-trafficked funnel; no external/dashboard gates.

## Changes
- **Hero — outcome-first (`components/Hero.tsx`).** H1 was method-forward ("Agent-speed delivery you can actually merge"). The buyer buys an *outcome*, so the H1 is now **"Ship the roadmap you can't hire for."** with the mechanism demoted to the eyebrow. Primary CTA switched from the high-friction call to the **free `/teardown`**; scoping call is the secondary link. (Consistent with the homepage Start band and `/teardown`.)
- **O3-5 — one guarantee string (`data/index.ts` `GUARANTEE`).** Risk-reversal line surfaced beside the Hero, CaseStudy, and Services money CTAs. Dedupes the previously-hardcoded ServicesHero copy into the shared constant.
- **O3-2 — €1k Reviewed PR async path (`components/services/EntryOffer.tsx`).** Adds a no-call path: a prefilled `mailto` ("send the ticket, skip the call") beside the Calendly CTA, so a first-time skeptic can start without booking. Stripe buy-now (O3-3) can replace the mailto once the account exists.

## Notes
- Also added `CONTACT_EMAIL` to `data/index.ts` for the async intake.
- Purely copy/CTA + one shared constant; no logic paths touched.

Gate: `tsc --noEmit` ✓ · lint ✓ · 20 jest tests ✓ · `npm run build` ✓.

## Remaining plan (post-merge)
- T2-1 `link-real-receipts` — still G4-parked (needs a publishable diff repo).
- Initiative 4 instrumentation — gated on G1 (Vercel plan tier for custom events).
- O3-3 Stripe buy-now, Initiative 5 nurture, Initiative 6 compounding — later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)