### PR TITLE
✨ M4-1 — typed analytics track() util + PII guard

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment node
+ */
+import { track } from "@/lib/analytics";
+
+// Jest runs with NODE_ENV=test, so config.isProduction is false — track() takes
+// the dev path: it runs the PII guard, then no-ops (no event is sent).
+describe("track() — PII guard (dev path)", () => {
+  it("throws when a prop key looks like PII", () => {
+    expect(() => track("cta_click", { email: "founder@startup.io" })).toThrow(
+      /PII/i,
+    );
+    expect(() => track("cta_click", { fullName: "Jane" })).toThrow(/PII/i);
+    expect(() => track("email_submit", { phone: "123" })).toThrow(/PII/i);
+  });
+
+  it("does not throw for safe props", () => {
+    expect(() => track("calendly_click", { source: "hero" })).not.toThrow();
+    expect(() => track("teardown_request")).not.toThrow();
+    expect(() =>
+      track("cta_click", { position: 2, featured: true }),
+    ).not.toThrow();
+  });
+});

--- a/components/TeardownForm.tsx
+++ b/components/TeardownForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import { track } from "@vercel/analytics";
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 type Status = "idle" | "loading" | "success" | "error";

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,44 @@
+import { track as vercelTrack } from "@vercel/analytics";
+
+// Local, side-effect-free production check. Deliberately NOT imported from
+// config/environment (whose module runs validateEnvironment() at load) so this
+// util can be pulled into statically-prerendered client components safely.
+const isProduction = process.env.NODE_ENV === "production";
+
+// The only events we fire. Kept small and tied to money actions so the funnel
+// stays legible at low volume — vanity metrics (scroll depth, generic views)
+// are deliberately excluded until traffic makes them meaningful.
+export type AnalyticsEvent =
+  | "calendly_click"
+  | "cta_click"
+  | "email_submit"
+  | "teardown_request"
+  | "audit_request";
+
+type PropValue = string | number | boolean;
+export type EventProps = Record<string, PropValue>;
+
+// Vercel Analytics is cookieless and we keep it PII-free. If a prop key looks
+// like PII, throw loudly in dev so it's caught before it can ship to prod.
+const PII_KEY = /email|name|phone|token|secret/i;
+
+const assertNoPii = (props: EventProps) => {
+  for (const key of Object.keys(props)) {
+    if (PII_KEY.test(key)) {
+      throw new Error(
+        `[analytics] refusing to send PII-shaped prop "${key}" — event props must never carry personal data`,
+      );
+    }
+  }
+};
+
+// Fire a named conversion event. No-op outside production so dev/preview don't
+// pollute the funnel data; in dev we still run the PII guard first so mistakes
+// surface at author time rather than in prod.
+export const track = (event: AnalyticsEvent, props?: EventProps): void => {
+  if (!isProduction) {
+    if (props) assertNoPii(props);
+    return;
+  }
+  vercelTrack(event, props);
+};


### PR DESCRIPTION
Initiative 4 (M4-1) of the lead-gen overhaul. The foundation for making the funnel measurable now that G1 is confirmed (Vercel Pro supports custom events).

## What
- **`lib/analytics.ts`** — typed `track(event, props?)` over `@vercel/analytics`. Event is a small string-literal union tied to money actions (`calendly_click`, `cta_click`, `email_submit`, `teardown_request`, `audit_request`) — vanity metrics deliberately excluded. No-ops outside production. A dev-time PII guard throws if any prop key matches `/email|name|phone|token|secret/i`, so PII can never ship as an event property (Vercel Analytics stays cookieless + PII-free).
- Refactors the existing `/teardown` call site off the raw `@vercel/analytics` import onto the util (its one current consumer).
- `__tests__/analytics.test.ts` — asserts the PII guard throws on PII-shaped keys and passes safe props.

## Design note
`isProduction` is computed locally (`process.env.NODE_ENV === "production"`) instead of importing `config/environment` — that module runs `validateEnvironment()` at load, and pulling that side-effect into a statically-prerendered client component (`/teardown`) broke the prerender. Decoupled.

Gate: `tsc --noEmit` ✓ · lint ✓ · 22 jest tests ✓ · `npm run build` ✓ (`/teardown` still static).

## Next (Init 4, unblocked now G1 passes)
M4-2 (`calendly_click{source}` on the CTAs via a CalendlyLink wrapper — mind the MagicButton Radix-Slot/beacon caveat), M4-3 (`email_submit` on EmailCapture + server), M4-4 (weekly KPI doc). Separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)