### PR TITLE
✨ M4-2/3/4 — instrument the CTA funnel (calendly_click / cta_click / email_submit)

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPost, getPosts } from "@/lib/blog";
-import { CALENDLY_URL } from "@/data";
+import { CalendlyLink } from "@/components/CalendlyLink";
 import PostHeader from "@/components/blog/PostHeader";
 import MDXContent from "@/components/blog/MDXContent";
 import TableOfContents from "@/components/blog/TableOfContents";
@@ -101,14 +101,12 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
               <p className="text-sm text-white-200 text-center">
                 Have a backlog you&apos;d want reviewed this way?{" "}
-                <a
-                  href={CALENDLY_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <CalendlyLink
+                  source="blog"
                   className="text-purple hover:text-purple/80 underline underline-offset-2 decoration-purple/40 transition-colors"
                 >
                   Book a scoping call →
-                </a>
+                </CalendlyLink>
               </p>
             </div>
           </div>

--- a/app/teardown/page.tsx
+++ b/app/teardown/page.tsx
@@ -119,6 +119,10 @@ export default function TeardownPage() {
               icon={<FaLocationArrow />}
               position="right"
               href={CALENDLY_URL}
+              trackEvent={{
+                event: "calendly_click",
+                props: { source: "teardown_book" },
+              }}
             />
             <a
               href="/services"

--- a/components/CalendlyLink.tsx
+++ b/components/CalendlyLink.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { track } from "@/lib/analytics";
+import { CALENDLY_URL } from "@/data";
+
+// Plain-anchor Calendly link that fires calendly_click{source} on click. Use
+// for the non-MagicButton CTAs; the styling comes from the caller's className
+// or children, so it drops into any existing anchor site.
+export const CalendlyLink = ({
+  source,
+  className,
+  children,
+  newTab = true,
+  ariaLabel,
+}: {
+  source: string;
+  className?: string;
+  children: React.ReactNode;
+  newTab?: boolean;
+  ariaLabel?: string;
+}) => (
+  <a
+    href={CALENDLY_URL}
+    onClick={() => track("calendly_click", { source })}
+    aria-label={ariaLabel}
+    {...(newTab ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+    className={className}
+  >
+    {children}
+  </a>
+);

--- a/components/CaseStudy.tsx
+++ b/components/CaseStudy.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { CALENDLY_URL, GUARANTEE } from "@/data";
+import { CalendlyLink } from "@/components/CalendlyLink";
+import { GUARANTEE } from "@/data";
 
 const CaseStudy = () => {
   return (
@@ -29,14 +30,12 @@ const CaseStudy = () => {
             Read the anatomy of nine agent batches →
           </Link>
           <span className="text-white-200/40">·</span>
-          <a
-            href={CALENDLY_URL}
-            target="_blank"
-            rel="noopener noreferrer"
+          <CalendlyLink
+            source="casestudy"
             className="text-sm font-medium text-blue-100 hover:text-purple transition-colors"
           >
             Book a scoping call
-          </a>
+          </CalendlyLink>
         </div>
         <p className="text-xs text-white-200/70 mt-6">{GUARANTEE}</p>
       </div>

--- a/components/EmailCapture.tsx
+++ b/components/EmailCapture.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 type Status = "idle" | "loading" | "success" | "error";
@@ -35,6 +36,7 @@ const EmailCapture = ({
         throw new Error("Subscription request failed");
       }
 
+      track("email_submit", { variant });
       setStatus("success");
       setEmail("");
     } catch {

--- a/components/FinalCta.tsx
+++ b/components/FinalCta.tsx
@@ -22,6 +22,10 @@ const FinalCta = () => {
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
+            trackEvent={{
+              event: "calendly_click",
+              props: { source: "final_cta" },
+            }}
           />
         </div>
         <p className="text-xs text-white-200/60 mt-6 max-w-xl mx-auto">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -32,6 +32,10 @@ const Footer = () => {
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
+            trackEvent={{
+              event: "calendly_click",
+              props: { source: "footer" },
+            }}
           />
           <a
             href="mailto:rusan.adrian.ionut@gmail.com"

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,7 +4,8 @@ import MagicButton from "./ui/MagicButton";
 import { TextGenerateEffect } from "./ui/TextGenerateEffect";
 import { FaLocationArrow } from "react-icons/fa6";
 import SpotlightBackground from "./ui/SpotlightBackground";
-import { CALENDLY_URL, GUARANTEE } from "@/data";
+import { CalendlyLink } from "@/components/CalendlyLink";
+import { GUARANTEE } from "@/data";
 
 const Hero = () => {
   return (
@@ -54,13 +55,18 @@ const Hero = () => {
               icon={<FaLocationArrow />}
               position="right"
               href="/teardown"
+              trackEvent={{
+                event: "cta_click",
+                props: { cta: "teardown", source: "hero" },
+              }}
             />
-            <a
-              href={CALENDLY_URL}
+            <CalendlyLink
+              source="hero_secondary"
+              newTab={false}
               className="text-sm font-medium text-blue-100 hover:text-purple transition-colors md:mt-10"
             >
               Or book a scoping call →
-            </a>
+            </CalendlyLink>
           </div>
 
           <p className="text-center text-xs text-white-200/70 mt-5 max-w-xl">

--- a/components/StartBand.tsx
+++ b/components/StartBand.tsx
@@ -1,5 +1,5 @@
 import MagicButton from "@/components/ui/MagicButton";
-import { CALENDLY_URL } from "@/data";
+import { CalendlyLink } from "@/components/CalendlyLink";
 import { FaLocationArrow } from "react-icons/fa6";
 
 // The primary conversion module: two low-commitment ways in, ordered by
@@ -43,6 +43,10 @@ export const StartBand = () => {
                 icon={<FaLocationArrow />}
                 position="right"
                 href="/teardown"
+                trackEvent={{
+                  event: "cta_click",
+                  props: { cta: "teardown", source: "startband" },
+                }}
               />
             </div>
           </div>
@@ -60,13 +64,14 @@ export const StartBand = () => {
               we&apos;ll fix the scope and the price before anything starts.
             </p>
             <div className="mt-6">
-              <a
-                href={CALENDLY_URL}
+              <CalendlyLink
+                source="startband_secondary"
+                newTab={false}
                 className="inline-flex items-center gap-2 text-sm font-medium text-blue-100 hover:text-purple transition-colors"
               >
                 Book a call
                 <FaLocationArrow className="text-xs" aria-hidden="true" />
-              </a>
+              </CalendlyLink>
             </div>
           </div>
         </div>

--- a/components/services/DeliverySprint.tsx
+++ b/components/services/DeliverySprint.tsx
@@ -117,6 +117,7 @@ export const DeliverySprint = () => {
             rows={rows}
             ctaHref={CALENDLY_URL}
             ctaLabel="Book a scoping call"
+            trackSource="deliverysprint_pricing"
           />
           <p className="text-xs text-white-200/70 mt-4 italic">
             Every sprint is priced on the reviewed outcome, not hours logged —
@@ -188,6 +189,10 @@ export const DeliverySprint = () => {
               icon={<FaLocationArrow />}
               position="right"
               href={CALENDLY_URL}
+              trackEvent={{
+                event: "calendly_click",
+                props: { source: "deliverysprint_bottom" },
+              }}
             />
           </div>
         </div>

--- a/components/services/EntryOffer.tsx
+++ b/components/services/EntryOffer.tsx
@@ -53,6 +53,10 @@ export const EntryOffer = () => {
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
+            trackEvent={{
+              event: "calendly_click",
+              props: { source: "entry_offer" },
+            }}
           />
           <a
             href={`mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(

--- a/components/services/HarnessSetup.tsx
+++ b/components/services/HarnessSetup.tsx
@@ -68,6 +68,10 @@ export const HarnessSetup = () => {
               icon={<FaLocationArrow />}
               position="right"
               href={CALENDLY_URL}
+              trackEvent={{
+                event: "calendly_click",
+                props: { source: "harness_top" },
+              }}
             />
           </div>
         </div>
@@ -107,6 +111,10 @@ export const HarnessSetup = () => {
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
+            trackEvent={{
+              event: "calendly_click",
+              props: { source: "harness_bottom" },
+            }}
           />
         </div>
       </div>

--- a/components/services/PricingTable.tsx
+++ b/components/services/PricingTable.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { track } from "@/lib/analytics";
 
 export interface PricingColumn {
   name: string;
@@ -16,6 +19,7 @@ export interface PricingTableProps {
   rows: PricingRow[];
   ctaHref: string;
   ctaLabel: string;
+  trackSource?: string;
 }
 
 export const PricingTable = ({
@@ -23,6 +27,7 @@ export const PricingTable = ({
   rows,
   ctaHref,
   ctaLabel,
+  trackSource,
 }: PricingTableProps) => {
   return (
     <div className="overflow-x-auto">
@@ -85,6 +90,13 @@ export const PricingTable = ({
                 <Link
                   href={ctaHref}
                   aria-label={ctaLabel}
+                  onClick={() =>
+                    trackSource &&
+                    track("calendly_click", {
+                      source: trackSource,
+                      tier: column.name,
+                    })
+                  }
                   {...(ctaHref.startsWith("http")
                     ? { target: "_blank", rel: "noopener noreferrer" }
                     : {})}

--- a/components/services/Retainer.tsx
+++ b/components/services/Retainer.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import MagicButton from "@/components/ui/MagicButton";
+import { CalendlyLink } from "@/components/CalendlyLink";
 import { CALENDLY_URL } from "@/data";
 import { FaLocationArrow } from "react-icons/fa6";
 
@@ -68,17 +68,11 @@ export const Retainer = () => {
             card; specifics are scoped on the call.
           </p>
           <div className="mt-6">
-            <Link
-              href={CALENDLY_URL}
-              aria-label="Book a scoping call"
-              {...(CALENDLY_URL.startsWith("http")
-                ? { target: "_blank", rel: "noopener noreferrer" }
-                : {})}
-            >
+            <CalendlyLink source="retainer_top" ariaLabel="Book a scoping call">
               <span className="inline-flex items-center rounded-lg border border-purple/40 px-4 py-2 text-xs font-medium text-purple hover:bg-purple/10 transition-colors">
                 Book a scoping call
               </span>
-            </Link>
+            </CalendlyLink>
           </div>
         </div>
         <p className="text-xs text-white-200/70 mt-4 italic">
@@ -131,6 +125,10 @@ export const Retainer = () => {
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
+            trackEvent={{
+              event: "calendly_click",
+              props: { source: "retainer_bottom" },
+            }}
           />
         </div>
       </div>

--- a/components/services/ServicesFinalCta.tsx
+++ b/components/services/ServicesFinalCta.tsx
@@ -25,6 +25,10 @@ export const ServicesFinalCta = () => {
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
+            trackEvent={{
+              event: "calendly_click",
+              props: { source: "services_final_cta" },
+            }}
           />
         </div>
         <Link

--- a/components/services/ServicesHero.tsx
+++ b/components/services/ServicesHero.tsx
@@ -37,6 +37,10 @@ export const ServicesHero = () => {
             icon={<FaLocationArrow />}
             position="right"
             href={CALENDLY_URL}
+            trackEvent={{
+              event: "calendly_click",
+              props: { source: "services_hero" },
+            }}
           />
           <a
             href="#process"

--- a/components/ui/FloatingNav.tsx
+++ b/components/ui/FloatingNav.tsx
@@ -10,6 +10,7 @@ import {
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { CALENDLY_URL } from "@/data";
+import { track } from "@/lib/analytics";
 
 export const FloatingNav = ({
   navItems,
@@ -78,6 +79,7 @@ export const FloatingNav = ({
           href={CALENDLY_URL}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => track("calendly_click", { source: "floating_nav" })}
           className="relative rounded-lg bg-purple px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple/80 !cursor-pointer"
         >
           Book a call

--- a/components/ui/MagicButton.tsx
+++ b/components/ui/MagicButton.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import { Button } from "./button";
+import { track, type AnalyticsEvent, type EventProps } from "@/lib/analytics";
 
 const magicClasses =
   "relative w-full inline-flex h-12 overflow-hidden rounded-lg p-[1px] focus:outline-none md:w-60 md:mt-10";
@@ -11,6 +14,7 @@ const MagicButton = ({
   handleClick,
   otherClasses,
   href,
+  trackEvent,
 }: {
   title: string;
   icon: React.ReactNode;
@@ -18,7 +22,14 @@ const MagicButton = ({
   handleClick?: () => void;
   otherClasses?: string;
   href?: string;
+  // Serializable so server components can request tracking without passing a
+  // function across the server/client boundary.
+  trackEvent?: { event: AnalyticsEvent; props?: EventProps };
 }) => {
+  const fireTrack = () => {
+    if (trackEvent) track(trackEvent.event, trackEvent.props);
+  };
+
   const inner = (
     <>
       <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] motion-reduce:animate-none bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
@@ -40,6 +51,7 @@ const MagicButton = ({
       <Button asChild className={magicClasses}>
         <Link
           href={href}
+          onClick={fireTrack}
           {...(isExternal
             ? { target: "_blank", rel: "noopener noreferrer" }
             : {})}
@@ -51,7 +63,13 @@ const MagicButton = ({
   }
 
   return (
-    <Button className={magicClasses} onClick={handleClick}>
+    <Button
+      className={magicClasses}
+      onClick={() => {
+        handleClick?.();
+        fireTrack();
+      }}
+    >
       {inner}
     </Button>
   );

--- a/notes/metrics-2026-07-10.md
+++ b/notes/metrics-2026-07-10.md
@@ -1,0 +1,40 @@
+# Funnel Metrics & Weekly Ritual — 2026-07-10
+
+Initiative 4 (M4-4) of `docs/plans/lead-gen-overhaul/plan-0.md`. How to read the funnel now that it's instrumented.
+
+## Tool
+**Vercel Web Analytics custom events** via `lib/analytics.ts` `track()`. No second vendor, cookieless, no consent banner, no PII in props (a dev-time guard throws if a prop key looks like PII). Confirmed on Vercel **Pro** (G1 passed), so custom events are recorded. Read them at **Vercel → project → Analytics → Events**, filterable by `utm_source` (Vercel captures UTM on pageviews natively).
+
+## Events instrumented (M4-2 / M4-3)
+| Event | Props | Where |
+|-------|-------|-------|
+| `calendly_click` | `source` (+`tier` on pricing) | every "Book a scoping call" CTA — sources: `hero_secondary`, `startband_secondary`, `floating_nav`, `casestudy`, `blog`, `footer`, `final_cta`, `services_hero`, `services_final_cta`, `entry_offer`, `retainer_top`, `retainer_bottom`, `deliverysprint_pricing`, `deliverysprint_bottom`, `harness_top`, `harness_bottom`, `teardown_book` |
+| `cta_click` | `cta:"teardown"`, `source` | the free-teardown primary CTAs — `hero`, `startband` |
+| `email_submit` | `variant` (`inline`/`footer`) | EmailCapture success |
+| `teardown_request` | — | `/teardown` form success |
+
+## Outreach link convention (so channels are attributable)
+Always tag the links you send:
+- LinkedIn post → `?utm_source=linkedin&utm_medium=post`
+- Cold email → `?utm_source=coldemail&utm_medium=email&utm_campaign=<batch>`
+- Warm DM → `?utm_source=warm&utm_medium=dm`
+
+## The 6 KPIs (weekly, < 5 min)
+1. **Unique visitors** (Vercel pageviews) — the denominator.
+2. **`calendly_click` count + rate** (clicks ÷ visitors) — booking intent.
+3. **`calendly_click` by `utm_source` and by `source`** — which *channel* and which *placement* drive intent.
+4. **`teardown_request` + `cta_click{cta:teardown}`** — async-funnel engagement (the low-friction rung).
+5. **`email_submit` + visitor→lead rate** — top-of-funnel capture.
+6. **Actual Calendly bookings** (pulled manually from Calendly) — ground-truth outcome.
+
+## Decision rule
+- **Leading indicator** = `calendly_click` + `teardown_request` by `utm_source`. **Lagging** = bookings.
+- Each week, **shift outreach effort to the `utm_source` with the highest intent-per-visit.** If LinkedIn drives 5× the click-rate of cold email, do more LinkedIn.
+- Watch `source` (placement) to spot dead CTAs — if a placement gets views but ~0 clicks, the copy/position there is wrong.
+- Cross-check the activity cadence in `outreach-list-2026-07-10.md`: if bookings are flat, the leading indicator tells you whether it's a *traffic* problem (low clicks → send more) or a *conversion* problem (clicks but no bookings → Calendly friction / qualification).
+
+## Privacy posture
+Cookieless, no consent banner required, no `email`/`name`/`phone` ever sent as an event prop (enforced by the dev-time PII guard in `lib/analytics.ts`). Data retention on Vercel is limited — this ritual reads recent windows, so that's fine.
+
+## Server-side `email_submit` (deferred)
+Client-side `email_submit` covers the KPI. A server-side mirror (from `/api/subscribe`) to reconcile beacon loss is deliberately deferred — add only if client-side under-counts noticeably.


### PR DESCRIPTION
Completes Initiative 4 (M4-1 shipped in #24). Makes the funnel measurable now that G1 passed (Vercel Pro supports custom events).

## Events
- **`calendly_click{source}`** on every "Book a scoping call" CTA — 17 distinct sources across homepage, services, blog, nav, footer (pricing table also tags `tier`).
- **`cta_click{cta:"teardown", source}`** on the free-teardown primaries (`hero`, `startband`).
- **`email_submit{variant}`** on EmailCapture success (no PII).
- (`teardown_request` already fires from `/teardown`.)

## How (two clean mechanisms — server components can't pass onClick to a client child)
- **`MagicButton`** is now a client component with a serializable **`trackEvent={{event, props}}`** prop; fires on click in both the href (Radix Slot `<Link>`) and button paths.
- New **`CalendlyLink`** client wrapper for the plain-anchor CTAs (Hero/StartBand secondary, CaseStudy, blog, Retainer top).
- **`PricingTable`** gains a `trackSource` prop; **`FloatingNav`** (already client) fires inline.

## PII safety
All events route through `lib/analytics.ts`, whose dev-time guard throws if any prop key looks like PII — no email/name/phone can be sent as a property.

## M4-4
`notes/metrics-2026-07-10.md` — the 6 KPIs, the UTM link convention for outreach attribution, and the weekly < 5-min ritual (leading = `calendly_click` by `utm_source`, lagging = bookings; decision rule = shift outreach to the highest-intent channel).

## Deferred
Server-side `email_submit` mirror (client covers the KPI); `scroll_depth`/`offer_view` vanity events (cut per the thin-instrumentation decision).

Gate: `tsc --noEmit` ✓ · lint ✓ · 22 jest tests ✓ · `npm run build` ✓ (all pages still prerender).

🤖 Generated with [Claude Code](https://claude.com/claude-code)